### PR TITLE
Add parameter for QuickSight identity region

### DIFF
--- a/cudos/shell-script/lib/common.sh
+++ b/cudos/shell-script/lib/common.sh
@@ -115,12 +115,19 @@ function get_cur_region() {
     export region=${aws_region}
     export AWS_DEFAULT_REGION=${aws_region}
   fi
+  # QuickSight User Identity may be from a different region than the dashboard deployment region
+  echo -n "Enter QuickSight Identity region [default : ${region}]: "
+  read aws_identity_region
+  if [ "${aws_identity_region}" = "" ]; then
+    export aws_identity_region=${region}
+  fi
 }
 
 function get_user_arn() {
   if [ "${user_arn}" = "" ]; then
     echo "Fetching QuickSight User ARNs..."
-    alias=$(aws quicksight list-users --aws-account-id ${account} --region ${aws_region} --namespace default --query 'UserList[*].Arn' --output text)
+    # Fetching quicksight users, which may be from an alternate region from the dashboard deployment
+    alias=$(aws quicksight list-users --aws-account-id ${account} --region ${aws_identity_region} --namespace default --query 'UserList[*].Arn' --output text)
     echo "Discovered QuickSight User ARNs.
 Please select which one to use:
 ----"


### PR DESCRIPTION
The customer may have configured their QuickSight deployment in a different region than where they want to deploy the dashboards.  Added an additional "optional" parameter that uses the just selected region as a default, but offers the customer an option to select an alternate region.

This is to avoid the error on "aws quicksight list-users":
  An error occurred (AccessDeniedException) when calling the ListUsers operation: Operation is being called from endpoint {dashboard region, e.g. us-west-2}, but your identity region is {identity region, e.g. us-east-1}. Please use the {identity region, e.g. us-east-1} endpoint.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
