### PR TITLE
Fix "unary operator expected" bug

### DIFF
--- a/cudos/shell-script/customer-cudos.sh
+++ b/cudos/shell-script/customer-cudos.sh
@@ -175,10 +175,10 @@ then
    exit
 fi
 echo "latest available template version is ${current_dashboard_source_version}"
-if [ ${current_dashboard_source_version} -eq ${latest_template_version} ]; then
+if [[ "${current_dashboard_source_version}" -eq "${latest_template_version}" ]]; then
     echo "You have the latest version deployed, no update required, exiting"
     exit
-elif [ ${current_dashboard_source_version} -gt ${latest_template_version} ]; then
+elif [[ "${current_dashboard_source_version}" -gt "${latest_template_version}" ]]; then
     echo "Error: Your deployed version is newer than the latest template, please check your installation, exiting"
     exit
 fi


### PR DESCRIPTION
Fix "unary operator expected" bug when checking for updates to the cudos dasbboard

*Issue #, if available:* Running dashboard update results in an error "unary operator expected"

*Description of changes:* added quotes around the ${current_dashboard_source_version}, ${latest_template_version} variables in the if statement.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
