### PR TITLE
Add --result-configuration OutputLocation parameter.

### DIFF
--- a/cudos/shell-script/lib/common.sh
+++ b/cudos/shell-script/lib/common.sh
@@ -12,6 +12,9 @@ required_cli_ver="2.1.17"
 required_cli1x_ver="1.18.139"
 aws_data_catalog_name="AwsDataCatalog"
 
+# Global Variables
+read -p "Enter your query execution result location:  " result_location
+
 # Tooling
 git=$(which git)
 
@@ -183,7 +186,7 @@ function execute_ahq() {
     local ahq_query="$1"
     query_execution_id=$(aws athena --region ${aws_region} start-query-execution \
         --query-execution-context Database=${athena_database_name},Catalog=${aws_data_catalog_name} \
-        --work-group "primary" --query-string "${ahq_query}" --query 'QueryExecutionId')
+        --work-group "primary" --query-string "${ahq_query}" --query 'QueryExecutionId' --result-configuration OutputLocation="${result_location}")
     ahq_query_status=$(ahq_query_status "${query_execution_id}")
     while [ "${ahq_query_status}" = "RUNNING" ]; do
         sleep 1
@@ -196,7 +199,7 @@ function execute_ahq_from_file() {
     local ahq_query_file="$1"
     query_execution_id=$(aws athena --region ${AWS_DEFAULT_REGION} start-query-execution \
         --query-execution-context Database=${athena_database_name},Catalog=${aws_data_catalog_name} \
-        --work-group "primary" --query-string "file://${ahq_query_file}" --query 'QueryExecutionId')
+        --work-group "primary" --query-string "file://${ahq_query_file}" --query 'QueryExecutionId' --result-configuration OutputLocation="${result_location}")
     ahq_query_status=$(ahq_query_status "${query_execution_id}")
     while [ "${ahq_query_status}" = "RUNNING" ]; do
         sleep 1

--- a/trends/shell-script/lib/common.sh
+++ b/trends/shell-script/lib/common.sh
@@ -15,6 +15,9 @@ required_cli_ver="2.1.17"
 required_cli1x_ver="1.18.139"
 aws_data_catalog_name="AwsDataCatalog"
 
+# Global Variables
+read -p "Enter your query execution result location:  " result_location
+
 # Tooling
 git=$(which git)
 
@@ -162,7 +165,7 @@ function execute_ahq() {
     local ahq_query="$1"
     query_execution_id=$(aws athena --region ${aws_region} start-query-execution \
         --query-execution-context Database=${athena_database_name},Catalog=${aws_data_catalog_name} \
-        --work-group "primary" --query-string "${ahq_query}" --query 'QueryExecutionId')
+        --work-group "primary" --query-string "${ahq_query}" --query 'QueryExecutionId' --result-configuration OutputLocation="${result_location}")
     ahq_query_status=$(ahq_query_status "${query_execution_id}")
     while [ "${ahq_query_status}" = "RUNNING" ]; do
         sleep 1
@@ -175,7 +178,7 @@ function execute_ahq_from_file() {
     local ahq_query_file="$1"
     query_execution_id=$(aws athena --region ${AWS_DEFAULT_REGION} start-query-execution \
         --query-execution-context Database=${athena_database_name},Catalog=${aws_data_catalog_name} \
-        --work-group "primary" --query-string "file://${ahq_query_file}" --query 'QueryExecutionId')
+        --work-group "primary" --query-string "file://${ahq_query_file}" --query 'QueryExecutionId' --result-configuration OutputLocation="${result_location}")
     ahq_query_status=$(ahq_query_status "${query_execution_id}")
     while [ "${ahq_query_status}" = "RUNNING" ]; do
         sleep 1


### PR DESCRIPTION
### *The Problem:*

When running the script without the --result-configuration Output Location parameter, the following error is displayed:

```bash
[cloudshell-user@ip-XX-XX-XX-XXX cudos]$ ./shell-script/customer-cudos.sh config
Checking environment
AWS CLI version...2.2.15...ok
Fetching AWS Account ID...ok
Enter QuickSight region: us-east-1 
Enter QuickSight Identity region [default : us-east-1]: 
Fetching Athena Database names...
Discovered Athena Database names.
Please select which one to use:
----
  1) awscosts
  2) alblogs
  3) cloudfront
  4) cloudtrail
  5) cost_usage_reports

#? 5
You have chosen cost_usage_reports
Fetching Athena Table names...

An error occurred (InvalidRequestException) when calling the StartQueryExecution operation: No output location provided. An output location is required either through the Workgroup result configuration setting or as an API input.

usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help

aws: error: argument --query-execution-id: expected one argument

Discovered Athena Table names. . Please select which one to use:
----

usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help

aws: error: argument --query-execution-id: expected one argument
```


### *Description of changes:*

Added the --result-configuration Output Location parameter to the code. Without this parameter, users have to edit the code manually, not being very productive.

### *Test:*

```bash
➜  cudos git:(feature/QUERY-RESULT-LOCATION) ✗ ./shell-script/customer-cudos.sh config
Enter your query execution result location:  s3://aws-athena-query-results-XXXXXX-us-east-1/
Checking environment
AWS CLI version...2.1.24...ok
Fetching AWS Account ID...ok
Enter QuickSight region: us-east-1
Enter QuickSight Identity region [default : us-east-1]:
Fetching Athena Database names...
Discovered Athena Database names.
Please select which one to use:

1) awscosts
2) alblogs
3) cloudfront
4) cloudtrail
5) cost_usage_reports

Discovered Athena Table names. . Please select which one to use:
----
 1) account_map
 2) aws_accounts
 3) aws_costs
 4) aws_costs_new
 5) aws_regions
 6) compute_savings_plan_eligible_spend
 7) daily_anomaly_detection
 8) ec2_running_cost
 9) cur_new
10) cur_old
11) ri_sp_mapping
12) s3_view
#?
```

### *Command Example:*

```bash
aws athena start-query-execution \
    --query-string "XPTO" \
    --query-execution-context Database=XPTO \
    **--result-configuration OutputLocation=s3://XPTO/** \
    --output text
```