### PR TITLE
improve error message, when missing perms

### DIFF
--- a/cid/common.py
+++ b/cid/common.py
@@ -494,8 +494,8 @@ class Cid:
                         print('created')
                     else:
                         print('failed')
-                except self.qs.client.exceptions.AccessDeniedException:
-                    print(f'unable to create, missing permissions')
+                except self.qs.client.exceptions.AccessDeniedException as AccessDeniedException:
+                    print('unable to create, missing permissions: {}'.format(AccessDeniedException))
 
         # Last chance to enter DataSetIds manually by user
         if len(missing_datasets):


### PR DESCRIPTION
*Description of changes:*

Currently if there is a permission error the message is ambiguous. I had to spend 3-4 hours of debugging span other a week :)  AWS side before I realized I could simply alter the code. 

Before vs After where Before is not verbose enough and might be confusing. 

```
Creating dataset: ec2_running_cost...unable to create, missing permissions
Creating dataset: s3_view...unable to create, missing permissions
Creating dataset: summary_view...unable to create, missing permissions
```


After

```
Creating dataset: ec2_running_cost...unable to create, missing permissions, An error occurred (AccessDeniedException) when calling the ListUsers operation: Operation is being called from endpoint us-east-1, but your identity region is eu-central-1. Please use the eu-central-1 endpoint.
Creating dataset: s3_view...unable to create, missing permissions, An error occurred (AccessDeniedException) when calling the ListUsers operation: Operation is being called from endpoint us-east-1, but your identity region is eu-central-1. Please use the eu-central-1 endpoint.
Creating dataset: summary_view...unable to create, missing permissions, An error occurred (AccessDeniedException) when calling the ListUsers operation: Operation is being called from endpoint us-east-1, but your identity region is eu-central-1. Please use the eu-central-1 endpoint.
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
