### PR TITLE
fix(athena): Athena query vars missing terminated quotes

### DIFF
--- a/cfn-templates/cudos-cfn.yml
+++ b/cfn-templates/cudos-cfn.yml
@@ -292,7 +292,7 @@ Resources:
                       AS SELECT DISTINCT 
                           line_item_usage_account_id account_id, 
                           line_item_usage_account_id account_name
-                      FROM {table_name}
+                      FROM \"{table_name}\"
                   """  
                   step = f"Executing account map query: {repr(account_map_query)}" 
                   logger.info(step)
@@ -312,7 +312,7 @@ Resources:
               queryId = athena.start_query_execution(
                   QueryString=f"""
                       SELECT COUNT(distinct {fieldName}) 
-                      FROM {database_name}.{table_name} 
+                      FROM \"{database_name}\".\"{table_name}\"
                       WHERE {fieldName} <> ''
                   """.strip(),
                   QueryExecutionContext={'Database': database_name},


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/aws-cudos-framework-deployment/issues/155

*Description of changes:*
Add terminated quotes to query strings for boto3.athena

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
