### PR TITLE
fixed describe_user call in user property of QuickSight helper

### DIFF
--- a/cid/helpers/quicksight.py
+++ b/cid/helpers/quicksight.py
@@ -187,7 +187,7 @@ class QuickSight():
     @property
     def user(self) -> dict:
         if not self._user:
-            self._user =  self.describe_user('/'.join(self.awsIdentity.get('Arn').split('/')[-2:]))
+            self._user =  self.describe_user('/'.join(self.awsIdentity.get('Arn').split('/')[1:]))
             if not self._user:
                 # If no user match, ask
                 userList = self.use1Client.list_users(AwsAccountId=self.account_id, Namespace='default').get('UserList')


### PR DESCRIPTION
*Issue #, if available:* fixes #174

*Description of changes:*

The describe_user call in the user property splits the AWS ARN on `/` and gets the last 2 values from the string. This might cause
issue when the ARN is an IAM User ARN (As described in #174). This commit fixes this behaviour by removing the initial `arn:aws:iam...` string instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
