### PR TITLE
Adding support for QuickSight regions other than us-east-1

### DIFF
--- a/cid/cli.py
+++ b/cid/cli.py
@@ -15,11 +15,13 @@ print(f'{prog_name} {version}\n')
 @click.option('--aws_access_key_id', help='', default=None)
 @click.option('--aws_secret_access_key', help='', default=None)
 @click.option('--aws_session_token', help='', default=None)
+@click.option('--quicksight_region', help="QuickSight Region (default:'us-east-1')", default=None)
 @click.option('-v', '--verbose', count=True)
 @click.pass_context
 def main(ctx, **kwargs):
     params = {
         'verbose': kwargs.pop('verbose'),
+        'quicksight_region': kwargs.pop('quicksight_region'),
     }
     App = Cid(**params)
     App.run(**kwargs)

--- a/cid/common.py
+++ b/cid/common.py
@@ -37,12 +37,15 @@ class Cid:
         self.awsIdentity = None
         self.session = None
         self.qs_url = 'https://{region}.quicksight.aws.amazon.com/sn/dashboards/{dashboard_id}'
+        self.qs_region = kwargs.pop('quicksight_region')
+        if self.qs_region is None:
+            self.qs_region = 'us-east-1'
 
     @property
     def qs(self) -> QuickSight:
         if not self._clients.get('quicksight'):
             self._clients.update({
-                'quicksight': QuickSight(self.session, self.awsIdentity, resources=self.resources)
+                'quicksight': QuickSight(self.session, self.awsIdentity, self.qs_region, resources=self.resources)
             })
         return self._clients.get('quicksight')
 
@@ -154,6 +157,7 @@ class Cid:
         logger.info(f'AWS userId: {self.awsIdentity.get("Arn").split(":")[5]}')
         print('\tRegion: {}'.format(self.session.region_name))
         logger.info(f'AWS region: {self.session.region_name}')
+        logger.info(f'QuickSight region: {self.qs_region}')
         print('done\n')
 
 


### PR DESCRIPTION
*Issue #, if available:*

The cdi-cli lacks support for QuickSight in regions other than us-east-1

*Description of changes:*

Added support of an additional command line parameter: --quicksight_region

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
