### PR TITLE
Fix (#221) - Ensure correct prefix is used in spice-refresh.yml

### DIFF
--- a/cfn-templates/spice-refresh-cfn.yml
+++ b/cfn-templates/spice-refresh-cfn.yml
@@ -20,7 +20,7 @@ Resources:
       RoleName: !Join
         - ''
         - - SpiceRefreshExecutionRole
-          - !Select [1 , !Split [ '-' , { "Fn::ImportValue" : {"Fn::Sub": "${cidTemplateName}-suffix" } } ] ]
+          - !Select [1 , !Split [ '_-' , { "Fn::ImportValue" : {"Fn::Sub": "${cidTemplateName}-suffix" } } ] ]
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -34,7 +34,7 @@ Resources:
         - PolicyName: !Join
           - ''
           - - SpiceRefreshExecutionPolicy
-            - { "Fn::ImportValue" : {"Fn::Sub": "${cidTemplateName}-suffix" } }
+            - !Select [1 , !Split [ '_-' , { "Fn::ImportValue" : {"Fn::Sub": "${cidTemplateName}-suffix" } } ] ]
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -65,14 +65,14 @@ Resources:
       FunctionName: !Join
         - ''
         - - QSCUDOSRefreshDatasets
-          - { "Fn::ImportValue" : {"Fn::Sub": "${cidTemplateName}-suffix" } }
+          - !Select [1 , !Split [ '_-' , { "Fn::ImportValue" : {"Fn::Sub": "${cidTemplateName}-suffix" } } ] ]
       Handler: index.lambda_handler
       MemorySize: 128
       Role: !GetAtt SpiceRefreshExecutionRole.Arn
       Timeout: 60
       Environment:
         Variables:
-          suffix: { "Fn::ImportValue" : {"Fn::Sub": "${cidTemplateName}-suffix" } }
+          suffix: !Select [1 , !Split [ '_-' , { "Fn::ImportValue" : {"Fn::Sub": "${cidTemplateName}-suffix" } } ] ]
       Code:
         ZipFile: |
           import boto3


### PR DESCRIPTION
*Issue #221 221*

*Description of changes:*
Fix for spice refresh not using the correct prefix if provided. This ensures that when a prefix is defined, it will use the correct value. The `cudos-cfn.yml` always adds `_-` as a default to whatever prefix is added. This will strip that value out and ensure the lambdas created and the env variable being uses match.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
