### PR TITLE
fix bats actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,12 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE }}
           role-session-name: ${{ secrets.AWS_SESSION_NAME }}
           aws-region: ${{ secrets.AWS_REGION }}
-      - name:  Test
+      - name: Setup BATS testing framework
+        uses: mig4/setup-bats@v1.2.0
+        with:
+          bats-version: 1.7.0
+      - name: Verify Bats
+        run: which bats && bats --version
+      - name: Test
         run: |
-          sudo apt-get install -y bats
           bats cid/test/bats/10-deploy-update-delete/cudos.bats


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change adds an actions to install bats instead of broken apt-get install 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
