### PR TITLE
Change: Stop reading legacy deployments information

### DIFF
--- a/cid/helpers/quicksight/__init__.py
+++ b/cid/helpers/quicksight/__init__.py
@@ -202,8 +202,7 @@ class QuickSight(CidBase):
                         logger.info(f"Detected dataset: \"{_dataset.name}\" ({_dataset.id} in {dashboard.name})")
                         dashboard.datasets.update({_dataset.name: _dataset.id})
                 except self.client.exceptions.AccessDeniedException:
-                    logger.info(f'Looking local config for {dashboardId}')
-                    dashboard.find_local_config()
+                    logger.info(f'Access denied describing DataSetId {dataset_id} for Dashboard {dashboardId}')
                 except self.client.exceptions.InvalidParameterValueException:
                     logger.info(f'Invalid dataset {dataset_id}')
             templateAccountId = _definition.get('sourceAccountId')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
As we do autodiscovery of the existing deployments, have resource take-over mechanism and share feature we no longer need to workaround reading legacy `.json` files with deployment info.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
