### PR TITLE
Default cfn template Suffix parameter to empty string

### DIFF
--- a/cfn-templates/cid-cfn.yml
+++ b/cfn-templates/cid-cfn.yml
@@ -133,6 +133,7 @@ Parameters:
   Suffix:
     Type: String
     Description: Leave Empty. Do not use this Suffix it is not fully supported. For testing purposes only.
+    Default: ""
   DeployCUDOSDashboard:
     Type: String
     Description: Deploy CUDOS Dashboard


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* Adds a default value for the "Suffix" CloudFormation parameter. This parameter is documented as for testing purposes only. Defaulting to an empty string allows easier integration for automated deployments, such as via Terraform. Prerequisite for https://github.com/aws-samples/aws-cudos-framework-deployment/pull/480.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
