### PR TITLE
Fix logic of Quicksight data source creation in CF

### DIFF
--- a/cfn-templates/cid-cfn.yml
+++ b/cfn-templates/cid-cfn.yml
@@ -209,7 +209,7 @@ Conditions:
     Fn::And:
       - !Condition NeedDataBucketsKms
       - !Condition NeedCURTable
-  NeedDatasource: !Equals [ !Ref "AWS::Region", "eu-west-3" ] # In eu-west-3 CFN QS Dataset resource is not availble yet.
+  NeedDatasource: !Not [ !Equals [ !Ref "AWS::Region", "eu-west-3" ] ] # In eu-west-3 CFN QS Dataset resource is not availble yet.
 
 
 Resources:


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* Fixes conditional logic for creation of Quicksight data source in CloudFormation. During a previous update, logic was added to not attempt to create a Quicksight datasource in CloudFormation if the region eu-west-3 because that region does not support QS data source creation in CloudFormation. The logic was reversed, however, such that the CF template only attempts to create the datasource in eu-west-3 and does not create it elsewhere. This can cause deployment failures in other regions because it is looking for a datasource `CID-Athena-1` that doesn't exist.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
