### PR TITLE
Prevent parallel SPICE refresh

### DIFF
--- a/cfn-templates/cid-cfn.yml
+++ b/cfn-templates/cid-cfn.yml
@@ -270,6 +270,8 @@ Resources:
         ZipFile: |
           import os
           from datetime import datetime
+          from datetime import timedelta
+          from datetime import timezone
           import boto3
 
           ## List of DataSets can be found in cid-cmd:
@@ -303,11 +305,18 @@ Resources:
                       name = dataset['Name']
                       if dataset['ImportMode'] != 'SPICE' or name not in DATASETS_TO_REFRESH:
                           continue
-                      ingestions = quicksight.get_paginator('list_ingestions').paginate(AwsAccountId=account_id, DataSetId=dataset['DataSetId'])
-                      running_ingestions = list(ingestions.search("Ingestions[?contains([`INITIALIZED`,`QUEUED`,`RUNNING`], IngestionStatus)][]"))
-                      if len(running_ingestions) > 0:
-                          print(f"INFO: Dataset {name} has one or more currently running ingestions. Skipping refresh.")
-                          print('DEBUG: running_ingestions=', running_ingestions)
+                      scheduled_ingestion = None
+                      for ingestions_page in quicksight.get_paginator('list_ingestions').paginate(AwsAccountId=account_id, DataSetId=dataset['DataSetId']):
+                          for ingestion in ingestions_page['Ingestions']:
+                              time_since_creation = datetime.now(timezone.utc) - ingestion['CreatedTime']
+                              if ingestion['RequestSource'] == 'SCHEDULED' and time_since_creation <= timedelta(days = 1, hours = 1):
+                                  scheduled_ingestion = ingestion
+                                  break
+                          if scheduled_ingestion is not None:
+                              break
+                      if scheduled_ingestion is not None:
+                          print(f"INFO: Dataset {name} has a scheduled ingestion within the last 24 hours. Skipping manual refresh.")
+                          print('DEBUG: scheduled_ingestion=', scheduled_ingestion)
                           continue
                       print(f"INFO: Refreshing dataset {name}")
                       res = quicksight.create_ingestion(

--- a/cfn-templates/cid-cfn.yml
+++ b/cfn-templates/cid-cfn.yml
@@ -243,6 +243,10 @@ Resources:
                 Action: quicksight:ListDatasets
                 Resource:
                   - !Sub 'arn:${AWS::Partition}:quicksight:${AWS::Region}:${AWS::AccountId}:dataset/*'
+              - Effect: Allow
+                Action: quicksight:ListIngestions
+                Resource:
+                  - !Sub 'arn:${AWS::Partition}:quicksight:${AWS::Region}:${AWS::AccountId}:dataset/*/ingestion/*'
 
   # Currently QS has no api for managing updates, so we need to set up a scheduled lambda.
   # Once QS will provide the API for scheduling this will be removed.
@@ -298,6 +302,12 @@ Resources:
                   for dataset in page['DataSetSummaries']:
                       name = dataset['Name']
                       if dataset['ImportMode'] != 'SPICE' or name not in DATASETS_TO_REFRESH:
+                          continue
+                      ingestions = quicksight.get_paginator('list_ingestions').paginate(AwsAccountId=account_id, DataSetId=dataset['DataSetId'])
+                      running_ingestions = list(ingestions.search("Ingestions[?contains([`INITIALIZED`,`QUEUED`,`RUNNING`], IngestionStatus)][]"))
+                      if len(running_ingestions) > 0:
+                          print(f"INFO: Dataset {name} has one or more currently running ingestions. Skipping refresh.")
+                          print('DEBUG: running_ingestions=', running_ingestions)
                           continue
                       print(f"INFO: Refreshing dataset {name}")
                       res = quicksight.create_ingestion(

--- a/cfn-templates/cid-cfn.yml
+++ b/cfn-templates/cid-cfn.yml
@@ -306,13 +306,19 @@ Resources:
                       if dataset['ImportMode'] != 'SPICE' or name not in DATASETS_TO_REFRESH:
                           continue
                       scheduled_ingestion = None
+                      stop_processing = False
                       for ingestions_page in quicksight.get_paginator('list_ingestions').paginate(AwsAccountId=account_id, DataSetId=dataset['DataSetId']):
                           for ingestion in ingestions_page['Ingestions']:
                               time_since_creation = datetime.now(timezone.utc) - ingestion['CreatedTime']
-                              if ingestion['RequestSource'] == 'SCHEDULED' and time_since_creation <= timedelta(days = 1, hours = 1):
-                                  scheduled_ingestion = ingestion
+                              if time_since_creation <= timedelta(days = 1, hours = 1):
+                                  if ingestion['RequestSource'] == 'SCHEDULED':
+                                      scheduled_ingestion = ingestion
+                                      stop_processing = True
+                              else:
+                                  stop_processing = True
+                              if stop_processing:
                                   break
-                          if scheduled_ingestion is not None:
+                          if stop_processing:
                               break
                       if scheduled_ingestion is not None:
                           print(f"INFO: Dataset {name} has a scheduled ingestion within the last 24 hours. Skipping manual refresh.")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Adds check to SPICE refresh Lambda function to skip the refresh if there is a recent scheduled refresh (within 25 hours). This prevents potential S3 throttling caused by scheduled and manual (Lambda-invoked) refreshes occurring at the same time.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
