### PR TITLE
Inclusion of MySQL Database Engine in Graviton Savings Calculation

### DIFF
--- a/cid/builtin/core/data/datasets/kpi/kpi_instance_all.json
+++ b/cid/builtin/core/data/datasets/kpi/kpi_instance_all.json
@@ -399,6 +399,14 @@
                     {
                         "Name": "lambda_graviton_potential_savings",
                         "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "rds_oracle_cost",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "rds_sql_server_cost",
+                        "Type": "DECIMAL"
                     }
                 ]
             }
@@ -518,7 +526,9 @@
                             "lambda_usage_cost",
                             "lambda_graviton_eligible_cost",
                             "lambda_graviton_cost",
-                            "lambda_graviton_potential_savings"
+                            "lambda_graviton_potential_savings",
+                            "rds_oracle_cost",
+                            "rds_sql_server_cost"
                         ]
                     }
                 }

--- a/cid/builtin/core/data/datasets/kpi/kpi_tracker.json
+++ b/cid/builtin/core/data/datasets/kpi/kpi_tracker.json
@@ -287,6 +287,22 @@
                     {
                         "Name": "lambda_graviton_potential_savings",
                         "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "rds_license",
+                        "Type": "INTEGER"
+                    },
+                    {
+                        "Name": "rds_no_license",
+                        "Type": "INTEGER"
+                    },
+                    {
+                        "Name": "rds_sql_server_cost",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "rds_oracle_cost",
+                        "Type": "DECIMAL"
                     }
                 ]
             }
@@ -368,7 +384,11 @@
                             "lambda_all_cost",
                             "lambda_graviton_cost",
                             "lambda_graviton_eligible_cost",
-                            "lambda_graviton_potential_savings"
+                            "lambda_graviton_potential_savings",
+                            "rds_license",
+                            "rds_no_license",
+                            "rds_sql_server_cost",
+                            "rds_oracle_cost"
                         ]
                     }
                 }

--- a/cid/builtin/core/data/queries/kpi/kpi_instance_all_view.sql
+++ b/cid/builtin/core/data/queries/kpi/kpi_instance_all_view.sql
@@ -97,7 +97,7 @@
 			cur_all.*  
 		   , CASE 
 				WHEN (product_code = 'AmazonEC2' AND lower(platform) NOT LIKE '%window%') THEN latest_graviton 
-				WHEN (product_code = 'AmazonRDS' AND database_engine in ('Aurora MySQL','Aurora PostgreSQL','MariaDB','PostgreSQL')) THEN latest_graviton 
+				WHEN (product_code = 'AmazonRDS' AND database_engine in ('Aurora MySQL','Aurora PostgreSQL','MariaDB','PostgreSQL','MySQL')) THEN latest_graviton 
 				WHEN (product_code = 'AmazonES') THEN latest_graviton
 				WHEN (product_code = 'AmazonElastiCache') THEN latest_graviton
 				END "latest_graviton"
@@ -175,20 +175,22 @@
 				WHEN (("charge_type" LIKE '%Usage%') AND ("product_code" = 'AmazonRDS') AND ("instance_type" <> '') AND (purchase_option = 'OnDemand')) THEN adjusted_amortized_cost ELSE 0 END "rds_ondemand_cost"				
 		   , CASE 
 				WHEN (("charge_type" LIKE '%Usage%') AND ("product_code" = 'AmazonRDS') AND (adjusted_processor = 'Graviton')) THEN amortized_cost 
-				WHEN (("charge_type" = 'Usage') AND ("product_code" = 'AmazonRDS') AND ("instance_type" <> '') AND (database_engine in ('Aurora MySQL','Aurora PostgreSQL','MariaDB','PostgreSQL')) AND (adjusted_processor <> 'Graviton')  AND (latest_graviton <> '')) THEN amortized_cost ELSE 0 END "rds_graviton_eligible_cost"
+				WHEN (("charge_type" = 'Usage') AND ("product_code" = 'AmazonRDS') AND ("instance_type" <> '') AND (database_engine in ('Aurora MySQL','Aurora PostgreSQL','MariaDB','PostgreSQL','MySQL')) AND (adjusted_processor <> 'Graviton')  AND (latest_graviton <> '')) THEN amortized_cost ELSE 0 END "rds_graviton_eligible_cost"
 		   , CASE 
-				WHEN (("charge_type" LIKE '%Usage%') AND ("product_code" = 'AmazonRDS') AND ("instance_type" <> '') AND (database_engine in ('Aurora MySQL','Aurora PostgreSQL','MariaDB','PostgreSQL')) AND (adjusted_processor = 'Graviton')) THEN amortized_cost ELSE 0 END "rds_graviton_cost"
+				WHEN (("charge_type" LIKE '%Usage%') AND ("product_code" = 'AmazonRDS') AND ("instance_type" <> '') AND (database_engine in ('Aurora MySQL','Aurora PostgreSQL','MariaDB','PostgreSQL','MySQL')) AND (adjusted_processor = 'Graviton')) THEN amortized_cost ELSE 0 END "rds_graviton_cost"
 		   , CASE 
 				WHEN ("charge_type" NOT LIKE '%Usage%') THEN 0 
 				WHEN ("product_code" <> 'AmazonRDS') THEN 0 
 				WHEN (adjusted_processor = 'Graviton') THEN 0 
 				WHEN (latest_graviton = '') THEN 0 
-				WHEN ((latest_graviton <> '') AND purchase_option = 'OnDemand' AND (database_engine in ('Aurora MySQL','Aurora PostgreSQL','MariaDB','PostgreSQL'))) THEN (amortized_cost * 1E-1) ELSE 0 END "rds_graviton_potential_savings"  /*Uses 10% savings estimate*/	
+				WHEN ((latest_graviton <> '') AND purchase_option = 'OnDemand' AND (database_engine in ('Aurora MySQL','Aurora PostgreSQL','MariaDB','PostgreSQL','MySQL'))) THEN (amortized_cost * 1E-1) ELSE 0 END "rds_graviton_potential_savings"  /*Uses 10% savings estimate*/	
 		   , CASE 
 				WHEN (("purchase_option" in ('Reserved','SavingsPlan')) AND ("product_code" = 'AmazonRDS')) THEN ("adjusted_amortized_cost" - "amortized_cost") ELSE 0 END "rds_commit_savings"	
 		   , CASE 
 				WHEN (("charge_type" LIKE '%Usage%') AND ("product_code" = 'AmazonRDS') AND ("instance_type" <> '') AND (purchase_option = 'OnDemand')) THEN (amortized_cost * 2E-1) ELSE 0 END "rds_commit_potential_savings"  /*Uses 20% savings estimate*/ 				
-				
+			, (CASE WHEN (((("charge_type" LIKE '%Usage%') AND ("product_code" = 'AmazonRDS')) AND ("instance_type" <> '')) AND (database_engine IN ('Oracle'))) THEN adjusted_amortized_cost ELSE 0 END) "rds_oracle_cost"
+			, (CASE WHEN (((("charge_type" LIKE '%Usage%') AND ("product_code" = 'AmazonRDS')) AND ("instance_type" <> '')) AND (database_engine IN ('SQL Server'))) THEN adjusted_amortized_cost ELSE 0 END) "rds_sql_server_cost"
+		
 /*ElastiCache*/			
 		   , CASE 
 				WHEN ("product_code" = 'AmazonElastiCache') THEN adjusted_amortized_cost ELSE 0 END "elasticache_all_cost"	 

--- a/cid/builtin/core/data/queries/kpi/kpi_instance_all_view_noRISP.sql
+++ b/cid/builtin/core/data/queries/kpi/kpi_instance_all_view_noRISP.sql
@@ -85,7 +85,7 @@
 			cur_all.*  
 		   , CASE 
 				WHEN (product_code = 'AmazonEC2' AND lower(platform) NOT LIKE '%window%') THEN latest_graviton 
-				WHEN (product_code = 'AmazonRDS' AND database_engine in ('Aurora MySQL','Aurora PostgreSQL','MariaDB','PostgreSQL')) THEN latest_graviton 
+				WHEN (product_code = 'AmazonRDS' AND database_engine in ('Aurora MySQL','Aurora PostgreSQL','MariaDB','PostgreSQL','MySQL')) THEN latest_graviton 
 				WHEN (product_code = 'AmazonES') THEN latest_graviton
 				WHEN (product_code = 'AmazonElastiCache') THEN latest_graviton
 				END "latest_graviton"
@@ -162,19 +162,22 @@
 				WHEN (("charge_type" LIKE '%Usage%') AND ("product_code" = 'AmazonRDS') AND ("instance_type" <> '') AND (purchase_option = 'OnDemand')) THEN adjusted_amortized_cost ELSE 0 END "rds_ondemand_cost"				
 		   , CASE 
 				WHEN (("charge_type" LIKE '%Usage%') AND ("product_code" = 'AmazonRDS') AND (adjusted_processor = 'Graviton')) THEN amortized_cost 
-				WHEN (("charge_type" = 'Usage') AND ("product_code" = 'AmazonRDS') AND ("instance_type" <> '') AND (database_engine in ('Aurora MySQL','Aurora PostgreSQL','MariaDB','PostgreSQL')) AND (adjusted_processor <> 'Graviton')  AND (latest_graviton <> '')) THEN amortized_cost ELSE 0 END "rds_graviton_eligible_cost"
+				WHEN (("charge_type" = 'Usage') AND ("product_code" = 'AmazonRDS') AND ("instance_type" <> '') AND (database_engine in ('Aurora MySQL','Aurora PostgreSQL','MariaDB','PostgreSQL','MySQL')) AND (adjusted_processor <> 'Graviton')  AND (latest_graviton <> '')) THEN amortized_cost ELSE 0 END "rds_graviton_eligible_cost"
 		   , CASE 
-				WHEN (("charge_type" LIKE '%Usage%') AND ("product_code" = 'AmazonRDS') AND ("instance_type" <> '') AND (database_engine in ('Aurora MySQL','Aurora PostgreSQL','MariaDB','PostgreSQL')) AND (adjusted_processor = 'Graviton')) THEN amortized_cost ELSE 0 END "rds_graviton_cost"
+				WHEN (("charge_type" LIKE '%Usage%') AND ("product_code" = 'AmazonRDS') AND ("instance_type" <> '') AND (database_engine in ('Aurora MySQL','Aurora PostgreSQL','MariaDB','PostgreSQL','MySQL')) AND (adjusted_processor = 'Graviton')) THEN amortized_cost ELSE 0 END "rds_graviton_cost"
 		   , CASE 
 				WHEN ("charge_type" NOT LIKE '%Usage%') THEN 0 
 				WHEN ("product_code" <> 'AmazonRDS') THEN 0 
 				WHEN (adjusted_processor = 'Graviton') THEN 0 
 				WHEN (latest_graviton = '') THEN 0 
-				WHEN ((latest_graviton <> '') AND purchase_option = 'OnDemand' AND (database_engine in ('Aurora MySQL','Aurora PostgreSQL','MariaDB','PostgreSQL'))) THEN (amortized_cost * 1E-1) ELSE 0 END "rds_graviton_potential_savings"  /*Uses 10% savings estimate*/	
+				WHEN ((latest_graviton <> '') AND purchase_option = 'OnDemand' AND (database_engine in ('Aurora MySQL','Aurora PostgreSQL','MariaDB','PostgreSQL','MySQL'))) THEN (amortized_cost * 1E-1) ELSE 0 END "rds_graviton_potential_savings"  /*Uses 10% savings estimate*/	
 		   , CASE 
 				WHEN (("purchase_option" in ('Reserved','SavingsPlan')) AND ("product_code" = 'AmazonRDS')) THEN ("adjusted_amortized_cost" - "amortized_cost") ELSE 0 END "rds_commit_savings"	
 		   , CASE 
-				WHEN (("charge_type" LIKE '%Usage%') AND ("product_code" = 'AmazonRDS') AND ("instance_type" <> '') AND (purchase_option = 'OnDemand')) THEN (amortized_cost * 2E-1) ELSE 0 END "rds_commit_potential_savings"  /*Uses 20% savings estimate*/ 				
+				WHEN (("charge_type" LIKE '%Usage%') AND ("product_code" = 'AmazonRDS') AND ("instance_type" <> '') AND (purchase_option = 'OnDemand')) THEN (amortized_cost * 2E-1) ELSE 0 END "rds_commit_potential_savings"  /*Uses 20% savings estimate*/ 		
+			, (CASE WHEN (((("charge_type" LIKE '%Usage%') AND ("product_code" = 'AmazonRDS')) AND ("instance_type" <> '')) AND (database_engine IN ('Oracle'))) THEN adjusted_amortized_cost ELSE 0 END) "rds_oracle_cost"
+			, (CASE WHEN (((("charge_type" LIKE '%Usage%') AND ("product_code" = 'AmazonRDS')) AND ("instance_type" <> '')) AND (database_engine IN ('SQL Server'))) THEN adjusted_amortized_cost ELSE 0 END) "rds_sql_server_cost"
+			
 				
 /*ElastiCache*/			
 		   , CASE 

--- a/cid/builtin/core/data/queries/kpi/kpi_instance_all_view_noSP.sql
+++ b/cid/builtin/core/data/queries/kpi/kpi_instance_all_view_noSP.sql
@@ -88,7 +88,7 @@
 			cur_all.*  
 		   , CASE 
 				WHEN (product_code = 'AmazonEC2' AND lower(platform) NOT LIKE '%window%') THEN latest_graviton 
-				WHEN (product_code = 'AmazonRDS' AND database_engine in ('Aurora MySQL','Aurora PostgreSQL','MariaDB','PostgreSQL')) THEN latest_graviton 
+				WHEN (product_code = 'AmazonRDS' AND database_engine in ('Aurora MySQL','Aurora PostgreSQL','MariaDB','PostgreSQL','MySQL')) THEN latest_graviton 
 				WHEN (product_code = 'AmazonES') THEN latest_graviton
 				WHEN (product_code = 'AmazonElastiCache') THEN latest_graviton
 				END "latest_graviton"
@@ -165,20 +165,23 @@
 				WHEN (("charge_type" LIKE '%Usage%') AND ("product_code" = 'AmazonRDS') AND ("instance_type" <> '') AND (purchase_option = 'OnDemand')) THEN adjusted_amortized_cost ELSE 0 END "rds_ondemand_cost"				
 		   , CASE 
 				WHEN (("charge_type" LIKE '%Usage%') AND ("product_code" = 'AmazonRDS') AND (adjusted_processor = 'Graviton')) THEN amortized_cost 
-				WHEN (("charge_type" = 'Usage') AND ("product_code" = 'AmazonRDS') AND ("instance_type" <> '') AND (database_engine in ('Aurora MySQL','Aurora PostgreSQL','MariaDB','PostgreSQL')) AND (adjusted_processor <> 'Graviton')  AND (latest_graviton <> '')) THEN amortized_cost ELSE 0 END "rds_graviton_eligible_cost"
+				WHEN (("charge_type" = 'Usage') AND ("product_code" = 'AmazonRDS') AND ("instance_type" <> '') AND (database_engine in ('Aurora MySQL','Aurora PostgreSQL','MariaDB','PostgreSQL','MySQL')) AND (adjusted_processor <> 'Graviton')  AND (latest_graviton <> '')) THEN amortized_cost ELSE 0 END "rds_graviton_eligible_cost"
 		   , CASE 
-				WHEN (("charge_type" LIKE '%Usage%') AND ("product_code" = 'AmazonRDS') AND ("instance_type" <> '') AND (database_engine in ('Aurora MySQL','Aurora PostgreSQL','MariaDB','PostgreSQL')) AND (adjusted_processor = 'Graviton')) THEN amortized_cost ELSE 0 END "rds_graviton_cost"
+				WHEN (("charge_type" LIKE '%Usage%') AND ("product_code" = 'AmazonRDS') AND ("instance_type" <> '') AND (database_engine in ('Aurora MySQL','Aurora PostgreSQL','MariaDB','PostgreSQL','MySQL')) AND (adjusted_processor = 'Graviton')) THEN amortized_cost ELSE 0 END "rds_graviton_cost"
 		   , CASE 
 				WHEN ("charge_type" NOT LIKE '%Usage%') THEN 0 
 				WHEN ("product_code" <> 'AmazonRDS') THEN 0 
 				WHEN (adjusted_processor = 'Graviton') THEN 0 
 				WHEN (latest_graviton = '') THEN 0 
-				WHEN ((latest_graviton <> '') AND purchase_option = 'OnDemand' AND (database_engine in ('Aurora MySQL','Aurora PostgreSQL','MariaDB','PostgreSQL'))) THEN (amortized_cost * 1E-1) ELSE 0 END "rds_graviton_potential_savings"  /*Uses 10% savings estimate*/	
+				WHEN ((latest_graviton <> '') AND purchase_option = 'OnDemand' AND (database_engine in ('Aurora MySQL','Aurora PostgreSQL','MariaDB','PostgreSQL','MySQL'))) THEN (amortized_cost * 1E-1) ELSE 0 END "rds_graviton_potential_savings"  /*Uses 10% savings estimate*/	
 		   , CASE 
 				WHEN (("purchase_option" in ('Reserved','SavingsPlan')) AND ("product_code" = 'AmazonRDS')) THEN ("adjusted_amortized_cost" - "amortized_cost") ELSE 0 END "rds_commit_savings"	
 		   , CASE 
 				WHEN (("charge_type" LIKE '%Usage%') AND ("product_code" = 'AmazonRDS') AND ("instance_type" <> '') AND (purchase_option = 'OnDemand')) THEN (amortized_cost * 2E-1) ELSE 0 END "rds_commit_potential_savings"  /*Uses 20% savings estimate*/ 				
-				
+			, (CASE WHEN (((("charge_type" LIKE '%Usage%') AND ("product_code" = 'AmazonRDS')) AND ("instance_type" <> '')) AND (database_engine IN ('Oracle'))) THEN adjusted_amortized_cost ELSE 0 END) "rds_oracle_cost"
+			, (CASE WHEN (((("charge_type" LIKE '%Usage%') AND ("product_code" = 'AmazonRDS')) AND ("instance_type" <> '')) AND (database_engine IN ('SQL Server'))) THEN adjusted_amortized_cost ELSE 0 END) "rds_sql_server_cost"
+	
+
 /*ElastiCache*/			
 		   , CASE 
 				WHEN ("product_code" = 'AmazonElastiCache') THEN adjusted_amortized_cost ELSE 0 END "elasticache_all_cost"	 

--- a/cid/builtin/core/data/queries/kpi/last_kpi_tracker_view.sql
+++ b/cid/builtin/core/data/queries/kpi/last_kpi_tracker_view.sql
@@ -70,6 +70,10 @@ spend_all.billing_period
 , instance_all.lambda_graviton_cost
 , instance_all.lambda_graviton_eligible_cost
 , instance_all.lambda_graviton_potential_savings
+, instance_all.rds_license
+, instance_all.rds_no_license
+, instance_all.rds_sql_server_cost
+, instance_all.rds_oracle_cost
 FROM
   (((((account_map
 LEFT JOIN (
@@ -107,6 +111,8 @@ LEFT JOIN (
    , "sum"("rds_graviton_potential_savings") "rds_graviton_potential_savings"
    , "sum"("rds_commit_potential_savings") "rds_commit_potential_savings"
    , "sum"("rds_commit_savings") "rds_commit_savings"
+   , "sum"((CASE WHEN ("license_model" IN ('License included', 'Bring your own license')) THEN 1 ELSE 0 END)) "rds_license"
+   , "sum"((CASE WHEN ("license_model" LIKE 'No license required') THEN 1 ELSE 0 END)) "rds_no_license"
    , "sum"("elasticache_all_cost") "elasticache_all_cost"
    , "sum"("elasticache_ondemand_cost") "elasticache_ondemand_cost"
    , "sum"("elasticache_graviton_cost") "elasticache_graviton_cost"
@@ -142,6 +148,8 @@ LEFT JOIN (
    , "sum"("lambda_graviton_cost") "lambda_graviton_cost"
    , "sum"("lambda_graviton_eligible_cost") "lambda_graviton_eligible_cost"
    , "sum"("lambda_graviton_potential_savings") "lambda_graviton_potential_savings"
+   , "sum"("rds_sql_server_cost") "rds_sql_server_cost"
+   , "sum"("rds_oracle_cost") "rds_oracle_cost"
    FROM
      kpi_instance_all
    GROUP BY 1, 2, 3


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. kpi_instance_all view updated to include :
    MySQL Database Engine in Graviton Savings Calculation
    New field showing Oracle and SQL Server database engine cost
2. kpi_tracker view updated to include :
    Field flagging RDS resources running on "'License included", "Bring your own license" or "No license required" model
    New field showing Oracle and SQL Server database engine cost


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
