### PR TITLE
Add us-gov-west-1 to the list of green regions

### DIFF
--- a/dashboards/sustainability-proxy-metrics/sustainability-proxy-metrics.yaml
+++ b/dashboards/sustainability-proxy-metrics/sustainability-proxy-metrics.yaml
@@ -744,7 +744,7 @@ views:
          , ROW ('eu-north-1', 'Sweden', 'Stockholm', '59.33', '18.07', 1)
          , ROW ('eu-west-1', 'Ireland', 'Dublin', '53.28', '-7.71', 1)
          , ROW ('us-east-2', 'USA', 'Ohio', '40.36', '-82.91', 1)
-         , ROW ('us-gov-west-1', 'USA', 'Oregon', '39.53', '-119.88', 0)
+         , ROW ('us-gov-west-1', 'USA', 'Oregon', '39.53', '-119.88', 1)
          , ROW ('us-west-1', 'USA', 'N. California', '36.55', '-119.89', 1)
          , ROW ('us-west-2', 'USA', 'Oregon', '43.82', '-120.33', 1)
          , ROW ('ap-east-1', 'Hong Kong', 'Hong Kong', '22.28', '114.15', 0)


### PR DESCRIPTION
*Issue #, if available:* us-gov-west-1 is not flagged as a green region, but it should be to reflect the official list available here: https://sustainability.aboutamazon.com/products-services/the-cloud

*Description of changes:* add us-gov-west-1 in the list of green regions


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
