### PR TITLE
Fix sus_geo_region_athena_view with all costs on last rolling month

### DIFF
--- a/dashboards/sustainability-proxy-metrics/sustainability-proxy-metrics.yaml
+++ b/dashboards/sustainability-proxy-metrics/sustainability-proxy-metrics.yaml
@@ -1021,7 +1021,7 @@ views:
       FROM
         (${athena_database_name}.${cur_table_name} cur
       INNER JOIN sus_aws_regions ON ("product_region" = sus_aws_regions.region_name))
-      WHERE ((((product_region <> '') AND (product_region <> 'global')) AND ((product_operation LIKE 'RunInstances%') AND (("bill_billing_period_start_date" >= ("date_trunc"('month', current_timestamp) - INTERVAL  '7' MONTH)) AND (CAST("concat"("year", '-', "month", '-01') AS date) >= ("date_trunc"('month', current_date) - INTERVAL  '7' MONTH))))) AND (line_item_usage_start_date > (current_date - INTERVAL  '1' MONTH)))
+      WHERE ((product_region <> '') AND (product_region <> 'global')) AND (CAST("concat"("year", '-', "month", '-01') AS date) >= ("date_trunc"('month', current_date) - INTERVAL '1' MONTH)) AND (line_item_usage_start_date > (current_date - INTERVAL '1' MONTH))
       GROUP BY bill_payer_account_id, line_item_usage_start_date, product_region, region_city, region_latitude, is95PercentRenewable, region_longitude
   sus_network:
     dependsOn:


### PR DESCRIPTION
Includes all resources costs (not only EC2) on the past month rolling (not 7 months)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
