### PR TITLE
cid-cfn.yml: Add validation on CFN parameter S3 bucket path

### DIFF
--- a/cfn-templates/cid-cfn.yml
+++ b/cfn-templates/cid-cfn.yml
@@ -171,6 +171,7 @@ Parameters:
     Type: String
     Description: The S3 path to the bucket created by the Cost Optimization Data Collection Lab. The path will need point to a folder containing /trusted-advisor and/or /compute-optimizer folders. You can leave the variable {account_id} in place, it will be replaced by current account ID automatically.
     Default: "s3://costoptimizationdata{account_id}"
+    AllowedPattern: '^s3://[a-z0-9](.)+[a-zA-Z0-9/]$'
   LambdaLayerBucketPrefix:
     Type: String
     Description: An S3 bucket with a Lambda layer


### PR DESCRIPTION
*Description of changes:*
Issue: Forgetting to put s3:// prefix OptimizationDataCollectionBucketPath would cost time to debug as the CFN stack deployed successfully but QuickSight dataset is empty due to the Athena table was not created.

This PR copies the validation from https://github.com/aws-samples/aws-cudos-framework-deployment/blob/main/cfn-templates/cid-cfn.yml#L118 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
