### PR TITLE
Fix option_details column

### DIFF
--- a/cid/builtin/core/data/queries/co/auto_scale_options.sql
+++ b/cid/builtin/core/data/queries/co/auto_scale_options.sql
@@ -98,7 +98,7 @@ SELECT * FROM (
         COALESCE(utilizationmetrics_cpu_maximum, 'na'), ';',
         COALESCE(utilizationmetrics_memory_maximum, 'na'), ';',
         COALESCE(currentconfiguration_desiredcapacity, 'na'), ';'
-    ) AS option_details,
+    ) AS option_details
    , cast(NULL as varchar(1)) as tags
 
     FROM
@@ -415,7 +415,7 @@ UNION SELECT
         COALESCE(recommendationoptions_3_projectedutilizationmetrics_cpu_maximum, 'na'), ';',
         COALESCE(recommendationoptions_3_projectedutilizationmetrics_memory_maximum, 'na'), ';',
         COALESCE(recommendationoptions_3_configuration_desiredcapacity, 'na')
-    ) AS option_details,
+    ) AS option_details
 
    , cast(NULL as varchar(1)) as tags
 

--- a/cid/builtin/core/data/queries/co/auto_scale_options.sql
+++ b/cid/builtin/core/data/queries/co/auto_scale_options.sql
@@ -87,19 +87,18 @@ SELECT * FROM (
               AND recommendationoptions_3_ondemandprice != '')          THEN TRY((CAST(current_ondemandprice AS double) - CAST(recommendationoptions_3_ondemandprice AS double)) * 730) ELSE 0E0 END
     ) as max_estimatedmonthlysavings_value_medium
    , CONCAT(
-         currentperformancerisk, ';',
-         currentconfiguration_instancetype, ';',
-         '', ';',
-         current_memory, ';',
-         current_vcpus, ';',
-         current_network, ';',
-         current_storage, ';',
-         '', ';',
-         utilizationmetrics_cpu_maximum, ';',
-         utilizationmetrics_memory_maximum, ';',
-         currentconfiguration_desiredcapacity, ';'
-
-       ) option_details
+        COALESCE(currentperformancerisk, 'na'), ';',
+        COALESCE(currentconfiguration_instancetype, 'na'), ';',
+        '', ';',
+        COALESCE(current_memory, 'na'), ';',
+        COALESCE(current_vcpus, 'na'), ';',
+        COALESCE(current_network, 'na'), ';',
+        COALESCE(current_storage, 'na'), ';',
+        '', ';',
+        COALESCE(utilizationmetrics_cpu_maximum, 'na'), ';',
+        COALESCE(utilizationmetrics_memory_maximum, 'na'), ';',
+        COALESCE(currentconfiguration_desiredcapacity, 'na'), ';'
+    ) AS option_details,
    , cast(NULL as varchar(1)) as tags
 
     FROM
@@ -128,19 +127,19 @@ UNION SELECT
         effectiverecommendationpreferencesenhancedinfrastructuremetrics
     ) ressouce_details
    , CONCAT(
-         utilizationmetrics_disk_read_bytes_per_second_maximum, ';',
-         utilizationmetrics_disk_read_ops_per_second_maximum, ';',
-         utilizationmetrics_disk_write_bytes_per_second_maximum, ';',
-         utilizationmetrics_disk_write_ops_per_second_maximum, ';',
-         utilizationmetrics_ebs_read_bytes_per_second_maximum, ';',
-         utilizationmetrics_ebs_read_ops_per_second_maximum, ';',
-         utilizationmetrics_ebs_write_bytes_per_second_maximum, ';',
-         utilizationmetrics_ebs_write_ops_per_second_maximum, ';',
-         utilizationmetrics_network_in_bytes_per_second_maximum, ';',
-         utilizationmetrics_network_out_bytes_per_second_maximum, ';',
-         utilizationmetrics_network_packets_in_per_second_maximum, ';',
-         utilizationmetrics_network_packets_out_per_second_maximum, ';'
-     ) utilizationmetrics
+        COALESCE(utilizationmetrics_disk_read_bytes_per_second_maximum, 'na'), ';',
+        COALESCE(utilizationmetrics_disk_read_ops_per_second_maximum, 'na'), ';',
+        COALESCE(utilizationmetrics_disk_write_bytes_per_second_maximum, 'na'), ';',
+        COALESCE(utilizationmetrics_disk_write_ops_per_second_maximum, 'na'), ';',
+        COALESCE(utilizationmetrics_ebs_read_bytes_per_second_maximum, 'na'), ';',
+        COALESCE(utilizationmetrics_ebs_read_ops_per_second_maximum, 'na'), ';',
+        COALESCE(utilizationmetrics_ebs_write_bytes_per_second_maximum, 'na'), ';',
+        COALESCE(utilizationmetrics_ebs_write_ops_per_second_maximum, 'na'), ';',
+        COALESCE(utilizationmetrics_network_in_bytes_per_second_maximum, 'na'), ';',
+        COALESCE(utilizationmetrics_network_out_bytes_per_second_maximum, 'na'), ';',
+        COALESCE(utilizationmetrics_network_packets_in_per_second_maximum, 'na'), ';',
+        COALESCE(utilizationmetrics_network_packets_out_per_second_maximum, 'na')
+    ) AS option_details
    , 'Option 1' option_name
    , currentconfiguration_instancetype option_from
    , recommendationoptions_1_configuration_instancetype option_to
@@ -192,19 +191,19 @@ UNION SELECT
               AND recommendationoptions_3_ondemandprice != '')          THEN TRY((CAST(current_ondemandprice AS double) - CAST(recommendationoptions_3_ondemandprice AS double)) * 730) ELSE 0E0 END
     ) as max_estimatedmonthlysavings_value_medium
    , CONCAT(
-         recommendationoptions_1_performancerisk, ';',
-         recommendationoptions_1_configuration_instancetype, ';',
-         recommendationoptions_1_migrationeffort, ';',
-         recommendationoptions_1_memory, ';',
-         recommendationoptions_1_vcpus, ';',
-         recommendationoptions_1_network, ';',
-         recommendationoptions_1_storage, ';',
-         '', ';', --platform diff
-         recommendationoptions_1_projectedutilizationmetrics_cpu_maximum, ';',
-         recommendationoptions_1_projectedutilizationmetrics_memory_maximum, ';',
-         recommendationoptions_1_configuration_desiredcapacity, ';'
+        COALESCE(recommendationoptions_1_performancerisk, 'na'), ';',
+        COALESCE(recommendationoptions_1_configuration_instancetype, 'na'), ';',
+        COALESCE(recommendationoptions_1_migrationeffort, 'na'), ';',
+        COALESCE(recommendationoptions_1_memory, 'na'), ';',
+        COALESCE(recommendationoptions_1_vcpus, 'na'), ';',
+        COALESCE(recommendationoptions_1_network, 'na'), ';',
+        COALESCE(recommendationoptions_1_storage, 'na'), ';',
+        'na', ';',
+        COALESCE(recommendationoptions_1_projectedutilizationmetrics_cpu_maximum, 'na'), ';',
+        COALESCE(recommendationoptions_1_projectedutilizationmetrics_memory_maximum, 'na'), ';',
+        COALESCE(recommendationoptions_1_configuration_desiredcapacity, 'na')
+    ) AS option_details
 
-       ) option_details
    , cast(NULL as varchar(1)) as tags
 
     FROM
@@ -298,19 +297,19 @@ UNION SELECT
               AND recommendationoptions_3_ondemandprice != '')          THEN TRY((CAST(current_ondemandprice AS double) - CAST(recommendationoptions_3_ondemandprice AS double)) * 730) ELSE 0E0 END
     ) as max_estimatedmonthlysavings_value_medium
    , CONCAT(
-         recommendationoptions_2_performancerisk, ';',
-         recommendationoptions_2_configuration_instancetype, ';',
-         recommendationoptions_2_migrationeffort, ';',
-         recommendationoptions_2_memory, ';',
-         recommendationoptions_2_vcpus, ';',
-         recommendationoptions_2_network, ';',
-         recommendationoptions_2_storage, ';',
-         '', ';', --platform diff
-         recommendationoptions_2_projectedutilizationmetrics_cpu_maximum, ';',
-         recommendationoptions_2_projectedutilizationmetrics_memory_maximum, ';',
-         recommendationoptions_2_configuration_desiredcapacity, ';'
+        COALESCE(recommendationoptions_2_performancerisk, 'na'), ';',
+        COALESCE(recommendationoptions_2_configuration_instancetype, 'na'), ';',
+        COALESCE(recommendationoptions_2_migrationeffort, 'na'), ';',
+        COALESCE(recommendationoptions_2_memory, 'na'), ';',
+        COALESCE(recommendationoptions_2_vcpus, 'na'), ';',
+        COALESCE(recommendationoptions_2_network, 'na'), ';',
+        COALESCE(recommendationoptions_2_storage, 'na'), ';',
+        'na', ';',
+        COALESCE(recommendationoptions_2_projectedutilizationmetrics_cpu_maximum, 'na'), ';',
+        COALESCE(recommendationoptions_2_projectedutilizationmetrics_memory_maximum, 'na'), ';',
+        COALESCE(recommendationoptions_2_configuration_desiredcapacity, 'na')
+    ) AS option_details
 
-       ) option_details
    , cast(NULL as varchar(1)) as tags
 
     FROM
@@ -405,19 +404,19 @@ UNION SELECT
               AND recommendationoptions_3_ondemandprice != '')          THEN TRY((CAST(current_ondemandprice AS double) - CAST(recommendationoptions_3_ondemandprice AS double)) * 730) ELSE 0E0 END
     ) as max_estimatedmonthlysavings_value_medium
    , CONCAT(
-         recommendationoptions_3_performancerisk, ';',
-         recommendationoptions_3_configuration_instancetype, ';',
-         recommendationoptions_3_migrationeffort, ';',
-         recommendationoptions_3_memory, ';',
-         recommendationoptions_3_vcpus, ';',
-         recommendationoptions_3_network, ';',
-         recommendationoptions_3_storage, ';',
-         '', ';', --platform diff
-         recommendationoptions_3_projectedutilizationmetrics_cpu_maximum, ';',
-         recommendationoptions_3_projectedutilizationmetrics_memory_maximum, ';',
-         recommendationoptions_3_configuration_desiredcapacity, ';'
+        COALESCE(recommendationoptions_3_performancerisk, 'na'), ';',
+        COALESCE(recommendationoptions_3_configuration_instancetype, 'na'), ';',
+        COALESCE(recommendationoptions_3_migrationeffort, 'na'), ';',
+        COALESCE(recommendationoptions_3_memory, 'na'), ';',
+        COALESCE(recommendationoptions_3_vcpus, 'na'), ';',
+        COALESCE(recommendationoptions_3_network, 'na'), ';',
+        COALESCE(recommendationoptions_3_storage, 'na'), ';',
+        'na', ';',
+        COALESCE(recommendationoptions_3_projectedutilizationmetrics_cpu_maximum, 'na'), ';',
+        COALESCE(recommendationoptions_3_projectedutilizationmetrics_memory_maximum, 'na'), ';',
+        COALESCE(recommendationoptions_3_configuration_desiredcapacity, 'na')
+    ) AS option_details,
 
-       ) option_details
    , cast(NULL as varchar(1)) as tags
 
     FROM

--- a/cid/builtin/core/data/queries/co/ebs_volume_options.sql
+++ b/cid/builtin/core/data/queries/co/ebs_volume_options.sql
@@ -67,13 +67,13 @@ SELECT
     ) as max_estimatedmonthlysavings_value_medium,
 
     CONCAT(
-        currentperformancerisk, ';', --  as performancerisk
-        currentconfiguration_volumetype, ';', --  as volumetype
-        currentconfiguration_volumesize, ';', --  as volumesize
-        currentconfiguration_volumebaselineiops, ';', --  as volumebaselineiops
-        currentconfiguration_volumebaselinethroughput, ';', --  as volumebaselinethroughput
-        currentconfiguration_volumeburstiops, ';', --  as volumeburstiops
-        currentconfiguration_volumeburstthroughput, ';' --  as volumeburstthroughput
+        COALESCE(currentperformancerisk, 'na'), ';',
+        COALESCE(currentconfiguration_volumetype, 'na'), ';',
+        COALESCE(currentconfiguration_volumesize, 'na'), ';',
+        COALESCE(currentconfiguration_volumebaselineiops, 'na'), ';',
+        COALESCE(currentconfiguration_volumebaselinethroughput, 'na'), ';',
+        COALESCE(currentconfiguration_volumeburstiops, 'na'), ';',
+        COALESCE(currentconfiguration_volumeburstthroughput, 'na'), ';'
     ) as option_details,
     tags as tags
 
@@ -144,14 +144,15 @@ UNION SELECT
     ) as max_estimatedmonthlysavings_value_medium,
 
     CONCAT(
-        recommendationoptions_1_performancerisk, ';', -- as performancerisk,
-        recommendationoptions_1_configuration_volumetype, ';', -- as volumetype,
-        recommendationoptions_1_configuration_volumesize, ';', -- as volumesize,
-        recommendationoptions_1_configuration_volumebaselineiops, ';', -- as volumebaselineiops,
-        recommendationoptions_1_configuration_volumebaselinethroughput, ';', -- as volumebaselinethroughput,
-        recommendationoptions_1_configuration_volumeburstiops, ';', -- as volumeburstiops,
-        recommendationoptions_1_configuration_volumeburstthroughput, ';' -- as volumeburstthroughput,
+        COALESCE(recommendationoptions_1_performancerisk, 'na'), ';',
+        COALESCE(recommendationoptions_1_configuration_volumetype, 'na'), ';',
+        COALESCE(recommendationoptions_1_configuration_volumesize, 'na'), ';',
+        COALESCE(recommendationoptions_1_configuration_volumebaselineiops, 'na'), ';',
+        COALESCE(recommendationoptions_1_configuration_volumebaselinethroughput, 'na'), ';',
+        COALESCE(recommendationoptions_1_configuration_volumeburstiops, 'na'), ';',
+        COALESCE(recommendationoptions_1_configuration_volumeburstthroughput, 'na'), ';'
     ) as option_details,
+
     tags as tags
 
 FROM
@@ -224,14 +225,15 @@ UNION SELECT
 
 
     CONCAT(
-        recommendationoptions_2_performancerisk, ';', -- as performancerisk,
-        recommendationoptions_2_configuration_volumetype, ';', -- as volumetype,
-        recommendationoptions_2_configuration_volumesize, ';', -- as volumesize,
-        recommendationoptions_2_configuration_volumebaselineiops, ';', -- as volumebaselineiops,
-        recommendationoptions_2_configuration_volumebaselinethroughput, ';', -- as volumebaselinethroughput,
-        recommendationoptions_2_configuration_volumeburstiops, ';', -- as volumeburstiops,
-        recommendationoptions_2_configuration_volumeburstthroughput, ';' -- as volumeburstthroughput,
+        COALESCE(recommendationoptions_2_performancerisk, 'na'), ';',
+        COALESCE(recommendationoptions_2_configuration_volumetype, 'na'), ';',
+        COALESCE(recommendationoptions_2_configuration_volumesize, 'na'), ';',
+        COALESCE(recommendationoptions_2_configuration_volumebaselineiops, 'na'), ';',
+        COALESCE(recommendationoptions_2_configuration_volumebaselinethroughput, 'na'), ';',
+        COALESCE(recommendationoptions_2_configuration_volumeburstiops, 'na'), ';',
+        COALESCE(recommendationoptions_2_configuration_volumeburstthroughput, 'na'), ';'
     ) as option_details,
+
     tags as tags
 
 FROM
@@ -303,14 +305,15 @@ WHERE
     ) as max_estimatedmonthlysavings_value_medium,
 
     CONCAT(
-        recommendationoptions_3_performancerisk, ';', -- as performancerisk,
-        recommendationoptions_3_configuration_volumetype, ';', -- as volumetype,
-        recommendationoptions_3_configuration_volumesize, ';', -- as volumesize,
-        recommendationoptions_3_configuration_volumebaselineiops, ';', -- as volumebaselineiops,
-        recommendationoptions_3_configuration_volumebaselinethroughput, ';', -- as volumebaselinethroughput,
-        recommendationoptions_3_configuration_volumeburstiops, ';', -- as volumeburstiops,
-        recommendationoptions_3_configuration_volumeburstthroughput, ';' -- as volumeburstthroughput,
+        COALESCE(recommendationoptions_3_performancerisk, 'na'), ';',
+        COALESCE(recommendationoptions_3_configuration_volumetype, 'na'), ';',
+        COALESCE(recommendationoptions_3_configuration_volumesize, 'na'), ';',
+        COALESCE(recommendationoptions_3_configuration_volumebaselineiops, 'na'), ';',
+        COALESCE(recommendationoptions_3_configuration_volumebaselinethroughput, 'na'), ';',
+        COALESCE(recommendationoptions_3_configuration_volumeburstiops, 'na'), ';',
+        COALESCE(recommendationoptions_3_configuration_volumeburstthroughput, 'na'), ';'
     ) as option_details,
+
     tags as tags
 
 FROM

--- a/cid/builtin/core/data/queries/co/ec2_instance_options.sql
+++ b/cid/builtin/core/data/queries/co/ec2_instance_options.sql
@@ -100,17 +100,17 @@ CREATE OR REPLACE VIEW compute_optimizer_ec2_instance_options AS
     ) as max_estimatedmonthlysavings_value_medium
 
    , CONCAT(
-         currentperformancerisk, ';',
-         currentinstancetype, ';',
-         '', ';',
-         current_memory, ';',
-         current_vcpus, ';',
-         current_network, ';',
-         current_storage, ';',
-         '', ';',
-         utilizationmetrics_cpu_maximum, ';',
-         utilizationmetrics_memory_maximum, ';'
-       ) option_details
+        COALESCE(currentperformancerisk, 'na'), ';',
+        COALESCE(currentinstancetype, 'na'), ';',
+        COALESCE('', 'na'), ';',
+        COALESCE(current_memory, 'na'), ';',
+        COALESCE(current_vcpus, 'na'), ';',
+        COALESCE(current_network, 'na'), ';',
+        COALESCE(current_storage, 'na'), ';',
+        COALESCE('', 'na'), ';',
+        COALESCE(utilizationmetrics_cpu_maximum, 'na'), ';',
+        COALESCE(utilizationmetrics_memory_maximum, 'na'), ';'
+   ) option_details
    , tags tags
    FROM
      compute_optimizer_ec2_instance_lines
@@ -184,24 +184,24 @@ UNION SELECT
               AND recommendationoptions_3_estimatedmonthlysavings_currency != '') THEN TRY_CAST(recommendationoptions_3_estimatedmonthlysavings_value as double) ELSE 0E0 END
     ) as max_estimatedmonthlysavings_value_medium
    , CONCAT(
-         recommendationoptions_1_performancerisk, ';',
-         recommendationoptions_1_instancetype, ';',
-         recommendationoptions_1_migrationeffort, ';',
-         recommendationoptions_1_memory, ';',
-         recommendationoptions_1_vcpus, ';',
-         recommendationoptions_1_network, ';',
-         recommendationoptions_1_storage, ';',
-         CONCAT(
-            (CASE WHEN (recommendationoptions_1_platformdifferences_isarchitecturedifferent = 'true') THEN 'Architecture ' ELSE '' END),
-            (CASE WHEN (recommendationoptions_1_platformdifferences_ishypervisordifferent = 'true') THEN 'Hypervisor ' ELSE '' END),
-            (CASE WHEN (recommendationoptions_1_platformdifferences_isinstancestoreavailabilitydifferent = 'true') THEN 'InstanceStoreAvailability ' ELSE '' END),
-            (CASE WHEN (recommendationoptions_1_platformdifferences_isnetworkinterfacedifferent = 'true') THEN 'NetworkInterface ' ELSE '' END),
-            (CASE WHEN (recommendationoptions_1_platformdifferences_isstorageinterfacedifferent = 'true') THEN 'StorageInterface ' ELSE '' END),
-            (CASE WHEN (recommendationoptions_1_platformdifferences_isvirtualizationtypedifferent = 'true') THEN 'VirtualizationType ' ELSE '' END)
-         ), ';',
-         recommendationoptions_1_projectedutilizationmetrics_cpu_maximum, ';',
-         recommendationoptions_1_projectedutilizationmetrics_memory_maximum, ';'
-       ) option_details
+        COALESCE(recommendationoptions_1_performancerisk, 'na'), ';',
+        COALESCE(recommendationoptions_1_instancetype, 'na'), ';',
+        COALESCE(recommendationoptions_1_migrationeffort, 'na'), ';',
+        COALESCE(recommendationoptions_1_memory, 'na'), ';',
+        COALESCE(recommendationoptions_1_vcpus, 'na'), ';',
+        COALESCE(recommendationoptions_1_network, 'na'), ';',
+        COALESCE(recommendationoptions_1_storage, 'na'), ';',
+        CONCAT(
+           (CASE WHEN (COALESCE(recommendationoptions_1_platformdifferences_isarchitecturedifferent, 'na') = 'true') THEN 'Architecture ' ELSE '' END),
+           (CASE WHEN (COALESCE(recommendationoptions_1_platformdifferences_ishypervisordifferent, 'na') = 'true') THEN 'Hypervisor ' ELSE '' END),
+           (CASE WHEN (COALESCE(recommendationoptions_1_platformdifferences_isinstancestoreavailabilitydifferent, 'na') = 'true') THEN 'InstanceStoreAvailability ' ELSE '' END),
+           (CASE WHEN (COALESCE(recommendationoptions_1_platformdifferences_isnetworkinterfacedifferent, 'na') = 'true') THEN 'NetworkInterface ' ELSE '' END),
+           (CASE WHEN (COALESCE(recommendationoptions_1_platformdifferences_isstorageinterfacedifferent, 'na') = 'true') THEN 'StorageInterface ' ELSE '' END),
+           (CASE WHEN (COALESCE(recommendationoptions_1_platformdifferences_isvirtualizationtypedifferent, 'na') = 'true') THEN 'VirtualizationType ' ELSE '' END)
+        ), ';',
+        COALESCE(recommendationoptions_1_projectedutilizationmetrics_cpu_maximum, 'na'), ';',
+        COALESCE(recommendationoptions_1_projectedutilizationmetrics_memory_maximum, 'na'), ';'
+   ) option_details
    , tags tags
    FROM
      compute_optimizer_ec2_instance_lines
@@ -275,23 +275,23 @@ UNION SELECT
               AND recommendationoptions_3_estimatedmonthlysavings_currency != '') THEN TRY_CAST(recommendationoptions_3_estimatedmonthlysavings_value as double) ELSE 0E0 END
     ) as max_estimatedmonthlysavings_value_medium
    , CONCAT(
-         recommendationoptions_2_performancerisk, ';',
-         recommendationoptions_2_instancetype, ';',
-         recommendationoptions_2_migrationeffort, ';',
-         recommendationoptions_2_memory, ';',
-         recommendationoptions_2_vcpus, ';',
-         recommendationoptions_2_network, ';',
-         recommendationoptions_2_storage, ';',
-         CONCAT(
-            (CASE WHEN (recommendationoptions_2_platformdifferences_isarchitecturedifferent = 'true') THEN 'Architecture ' ELSE '' END),
-            (CASE WHEN (recommendationoptions_2_platformdifferences_ishypervisordifferent = 'true') THEN 'Hypervisor ' ELSE '' END),
-            (CASE WHEN (recommendationoptions_2_platformdifferences_isinstancestoreavailabilitydifferent = 'true') THEN 'InstanceStoreAvailability ' ELSE '' END),
-            (CASE WHEN (recommendationoptions_2_platformdifferences_isnetworkinterfacedifferent = 'true') THEN 'NetworkInterface ' ELSE '' END),
-            (CASE WHEN (recommendationoptions_2_platformdifferences_isstorageinterfacedifferent = 'true') THEN 'StorageInterface ' ELSE '' END),
-            (CASE WHEN (recommendationoptions_2_platformdifferences_isvirtualizationtypedifferent = 'true') THEN 'VirtualizationType ' ELSE '' END)
-         ), ';',
-         recommendationoptions_2_projectedutilizationmetrics_cpu_maximum, ';',
-         recommendationoptions_2_projectedutilizationmetrics_memory_maximum, ';'
+        COALESCE(recommendationoptions_2_performancerisk, 'na'), ';',
+        COALESCE(recommendationoptions_2_instancetype, 'na'), ';',
+        COALESCE(recommendationoptions_2_migrationeffort, 'na'), ';',
+        COALESCE(recommendationoptions_2_memory, 'na'), ';',
+        COALESCE(recommendationoptions_2_vcpus, 'na'), ';',
+        COALESCE(recommendationoptions_2_network, 'na'), ';',
+        COALESCE(recommendationoptions_2_storage, 'na'), ';',
+        CONCAT(
+           (CASE WHEN (COALESCE(recommendationoptions_2_platformdifferences_isarchitecturedifferent, 'na') = 'true') THEN 'Architecture ' ELSE '' END),
+           (CASE WHEN (COALESCE(recommendationoptions_2_platformdifferences_ishypervisordifferent, 'na') = 'true') THEN 'Hypervisor ' ELSE '' END),
+           (CASE WHEN (COALESCE(recommendationoptions_2_platformdifferences_isinstancestoreavailabilitydifferent, 'na') = 'true') THEN 'InstanceStoreAvailability ' ELSE '' END),
+           (CASE WHEN (COALESCE(recommendationoptions_2_platformdifferences_isnetworkinterfacedifferent, 'na') = 'true') THEN 'NetworkInterface ' ELSE '' END),
+           (CASE WHEN (COALESCE(recommendationoptions_2_platformdifferences_isstorageinterfacedifferent, 'na') = 'true') THEN 'StorageInterface ' ELSE '' END),
+           (CASE WHEN (COALESCE(recommendationoptions_2_platformdifferences_isvirtualizationtypedifferent, 'na') = 'true') THEN 'VirtualizationType ' ELSE '' END)
+        ), ';',
+        COALESCE(recommendationoptions_2_projectedutilizationmetrics_cpu_maximum, 'na'), ';',
+        COALESCE(recommendationoptions_2_projectedutilizationmetrics_memory_maximum, 'na'), ';'
    ) option_details
    , tags as tags
    FROM
@@ -368,24 +368,24 @@ UNION SELECT
               AND recommendationoptions_3_estimatedmonthlysavings_currency != '') THEN TRY_CAST(recommendationoptions_3_estimatedmonthlysavings_value as double) ELSE 0E0 END
     ) as max_estimatedmonthlysavings_value_medium
    , CONCAT(
-         recommendationoptions_3_performancerisk, ';',
-         recommendationoptions_3_instancetype, ';',
-         recommendationoptions_3_migrationeffort, ';',
-         recommendationoptions_3_memory, ';',
-         recommendationoptions_3_vcpus, ';',
-         recommendationoptions_3_network, ';',
-         recommendationoptions_3_storage, ';',
-         CONCAT(
-            (CASE WHEN (recommendationoptions_3_platformdifferences_isarchitecturedifferent = 'true') THEN 'Architecture ' ELSE '' END),
-            (CASE WHEN (recommendationoptions_3_platformdifferences_ishypervisordifferent = 'true') THEN 'Hypervisor ' ELSE '' END),
-            (CASE WHEN (recommendationoptions_3_platformdifferences_isinstancestoreavailabilitydifferent = 'true') THEN 'InstanceStoreAvailability ' ELSE '' END),
-            (CASE WHEN (recommendationoptions_3_platformdifferences_isnetworkinterfacedifferent = 'true') THEN 'NetworkInterface ' ELSE '' END),
-            (CASE WHEN (recommendationoptions_3_platformdifferences_isstorageinterfacedifferent = 'true') THEN 'StorageInterface ' ELSE '' END),
-            (CASE WHEN (recommendationoptions_3_platformdifferences_isvirtualizationtypedifferent = 'true') THEN 'VirtualizationType ' ELSE '' END)
-         ), ';',
-         recommendationoptions_3_projectedutilizationmetrics_cpu_maximum, ';',
-         recommendationoptions_3_projectedutilizationmetrics_memory_maximum, ';'
-       ) option_details
+        COALESCE(recommendationoptions_3_performancerisk, 'na'), ';',
+        COALESCE(recommendationoptions_3_instancetype, 'na'), ';',
+        COALESCE(recommendationoptions_3_migrationeffort, 'na'), ';',
+        COALESCE(recommendationoptions_3_memory, 'na'), ';',
+        COALESCE(recommendationoptions_3_vcpus, 'na'), ';',
+        COALESCE(recommendationoptions_3_network, 'na'), ';',
+        COALESCE(recommendationoptions_3_storage, 'na'), ';',
+        CONCAT(
+           (CASE WHEN (COALESCE(recommendationoptions_3_platformdifferences_isarchitecturedifferent, 'na') = 'true') THEN 'Architecture ' ELSE '' END),
+           (CASE WHEN (COALESCE(recommendationoptions_3_platformdifferences_ishypervisordifferent, 'na') = 'true') THEN 'Hypervisor ' ELSE '' END),
+           (CASE WHEN (COALESCE(recommendationoptions_3_platformdifferences_isinstancestoreavailabilitydifferent, 'na') = 'true') THEN 'InstanceStoreAvailability ' ELSE '' END),
+           (CASE WHEN (COALESCE(recommendationoptions_3_platformdifferences_isnetworkinterfacedifferent, 'na') = 'true') THEN 'NetworkInterface ' ELSE '' END),
+           (CASE WHEN (COALESCE(recommendationoptions_3_platformdifferences_isstorageinterfacedifferent, 'na') = 'true') THEN 'StorageInterface ' ELSE '' END),
+           (CASE WHEN (COALESCE(recommendationoptions_3_platformdifferences_isvirtualizationtypedifferent, 'na') = 'true') THEN 'VirtualizationType ' ELSE '' END)
+        ), ';',
+        COALESCE(recommendationoptions_3_projectedutilizationmetrics_cpu_maximum, 'na'), ';',
+        COALESCE(recommendationoptions_3_projectedutilizationmetrics_memory_maximum, 'na'), ';'
+   ) option_details
    , tags tags
    FROM
      compute_optimizer_ec2_instance_lines

--- a/cid/builtin/core/data/queries/co/lambda_options.sql
+++ b/cid/builtin/core/data/queries/co/lambda_options.sql
@@ -56,15 +56,15 @@ CREATE OR REPLACE VIEW compute_optimizer_lambda_options AS
     ) as max_estimatedmonthlysavings_value_medium
 
    , CONCAT(
-         currentperformancerisk, ';', -- '-'
-         currentconfiguration_memorysize, ';',
-         current_costaverage, ';',
-         current_costaverage, ';',
-         utilizationmetrics_durationaverage, ';',
-         '', ';',
-         utilizationmetrics_durationmaximum, ';'
+          COALESCE(currentperformancerisk, 'na'), ';',
+          COALESCE(currentconfiguration_memorysize, 'na'), ';',
+          COALESCE(current_costaverage, 'na'), ';',
+          COALESCE(current_costaverage, 'na'), ';',
+          COALESCE(utilizationmetrics_durationaverage, 'na'), ';',
+          '', ';',
+          COALESCE(utilizationmetrics_durationmaximum, 'na'), ';'
+      ) option_details
 
-       ) option_details
    , cast('' as varchar(1)) as tags
 
    FROM
@@ -111,17 +111,15 @@ UNION SELECT
         CASE WHEN recommendationoptions_3_estimatedmonthlysavings_currency != '' THEN TRY_CAST(recommendationoptions_3_estimatedmonthlysavings_value as double) ELSE 0E0 END
     ) as max_estimatedmonthlysavings_value_medium
    , CONCAT(
-         '', ';',  --no performance risk
-         recommendationoptions_1_configuration_memorysize, ';',
-         recommendationoptions_1_costlow, ';',
-         recommendationoptions_1_costhigh, ';',
-         recommendationoptions_1_projectedutilizationmetrics_durationexpected,
-         recommendationoptions_1_projectedutilizationmetrics_durationlowerbound, ';',
-         recommendationoptions_1_projectedutilizationmetrics_durationupperbound, ';'
-    ) option_details
+          '', ';',  --no performance risk
+          COALESCE(recommendationoptions_1_configuration_memorysize, 'na'), ';',
+          COALESCE(recommendationoptions_1_costlow, 'na'), ';',
+          COALESCE(recommendationoptions_1_costhigh, 'na'), ';',
+          COALESCE(recommendationoptions_1_projectedutilizationmetrics_durationexpected, 'na'), ';',
+          COALESCE(recommendationoptions_1_projectedutilizationmetrics_durationlowerbound, 'na'), ';',
+          COALESCE(recommendationoptions_1_projectedutilizationmetrics_durationupperbound, 'na'), ';'
+      ) option_details
    , cast('' as varchar(1)) as tags
-
-
 
     FROM
         compute_optimizer_lambda_lines
@@ -169,14 +167,14 @@ UNION SELECT
         CASE WHEN recommendationoptions_3_estimatedmonthlysavings_currency != '' THEN TRY_CAST(recommendationoptions_3_estimatedmonthlysavings_value as double) ELSE 0E0 END
     ) as max_estimatedmonthlysavings_value_medium
    , CONCAT(
-         '', ';',  --no performance risk
-         recommendationoptions_2_configuration_memorysize, ';',
-         recommendationoptions_2_costlow, ';',
-         recommendationoptions_2_costhigh, ';',
-         recommendationoptions_2_projectedutilizationmetrics_durationexpected,
-         recommendationoptions_2_projectedutilizationmetrics_durationlowerbound, ';',
-         recommendationoptions_2_projectedutilizationmetrics_durationupperbound, ';'
-    ) option_details
+          '', ';',  --no performance risk
+          COALESCE(recommendationoptions_2_configuration_memorysize, 'na'), ';',
+          COALESCE(recommendationoptions_2_costlow, 'na'), ';',
+          COALESCE(recommendationoptions_2_costhigh, 'na'), ';',
+          COALESCE(recommendationoptions_2_projectedutilizationmetrics_durationexpected, 'na'), ';',
+          COALESCE(recommendationoptions_2_projectedutilizationmetrics_durationlowerbound, 'na'), ';',
+          COALESCE(recommendationoptions_2_projectedutilizationmetrics_durationupperbound, 'na'), ';'
+      ) option_details
    , cast('' as varchar(1)) as tags
 
 
@@ -229,17 +227,15 @@ UNION SELECT
         CASE WHEN recommendationoptions_3_estimatedmonthlysavings_currency != '' THEN TRY_CAST(recommendationoptions_3_estimatedmonthlysavings_value as double) ELSE 0E0 END
     ) as max_estimatedmonthlysavings_value_medium
    , CONCAT(
-         '', ';',  --no performance risk
-         recommendationoptions_3_configuration_memorysize, ';',
-         recommendationoptions_3_costlow, ';',
-         recommendationoptions_3_costhigh, ';',
-         recommendationoptions_3_projectedutilizationmetrics_durationexpected,
-         recommendationoptions_3_projectedutilizationmetrics_durationlowerbound, ';',
-         recommendationoptions_3_projectedutilizationmetrics_durationupperbound, ';'
-    ) option_details
+          '', ';',  --no performance risk
+          COALESCE(recommendationoptions_3_configuration_memorysize, 'na'), ';',
+          COALESCE(recommendationoptions_3_costlow, 'na'), ';',
+          COALESCE(recommendationoptions_3_costhigh, 'na'), ';',
+          COALESCE(recommendationoptions_3_projectedutilizationmetrics_durationexpected, 'na'), ';',
+          COALESCE(recommendationoptions_3_projectedutilizationmetrics_durationlowerbound, 'na'), ';',
+          COALESCE(recommendationoptions_3_projectedutilizationmetrics_durationupperbound, 'na'), ';'
+      ) option_details
    , cast(NULL as varchar(1)) as tags
-
-
 
     FROM
         compute_optimizer_lambda_lines


### PR DESCRIPTION
*Issue #, if available:*
CONCAT function with null values are not working as it returns null if any of columns used in CONCAT function nulls, therefore added coalesce to keep null columns as 'na' and CONCAT function will still work as expected.

*Description of changes:*

COALESCE function added to all option_details columns.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
