### PR TITLE
Bugfix to handle empty datasetarns

### DIFF
--- a/cid/helpers/quicksight/__init__.py
+++ b/cid/helpers/quicksight/__init__.py
@@ -258,7 +258,7 @@ class QuickSight(CidBase):
 
 
         # Fetch datasets
-        for dataset in dashboard.version.get('DataSetArns'):
+        for dataset in dashboard.version.get('DataSetArns',[]):
             dataset_id = dataset.split('/')[-1]
             try:
                 _dataset = self.describe_dataset(id=dataset_id)

--- a/cid/helpers/quicksight/__init__.py
+++ b/cid/helpers/quicksight/__init__.py
@@ -258,7 +258,7 @@ class QuickSight(CidBase):
 
 
         # Fetch datasets
-        for dataset in dashboard.version.get('DataSetArns',[]):
+        for dataset in dashboard.version.get('DataSetArns', []):
             dataset_id = dataset.split('/')[-1]
             try:
                 _dataset = self.describe_dataset(id=dataset_id)


### PR DESCRIPTION
*Issue #, if available:*
In some cases of older boto3 and botocore installed, 
boto3                     1.12.46
botocore                  1.15.46
dashboard.version.get('DataSetArns') can return a None value.

*Description of changes:*
Handle the cases where dashboard.version.get('DataSetArns') returns a None value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
