### PR TITLE
Fixed QS Data Source policy name collision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ venv.bak/
 
 #Local dev and testing files
 cfn-templates/parameters.local
+sandbox/

--- a/cfn-templates/cid-cfn.yml
+++ b/cfn-templates/cid-cfn.yml
@@ -1075,7 +1075,7 @@ Resources:
     Type: AWS::IAM::Policy
     Condition: NeedQuickSightDataSourceRoleAndODC
     Properties:
-      PolicyName: S3Access
+      PolicyName: QuickSightDataSource-S3AccessODC
       PolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -1099,7 +1099,7 @@ Resources:
     Type: AWS::IAM::Policy
     Condition: NeedQuickSightDataSourceRoleAndCUR
     Properties:
-      PolicyName: S3Access
+      PolicyName: QuickSightDataSource-S3AccessCUR
       PolicyDocument:
         Version: 2012-10-17
         Statement:

--- a/cfn-templates/cid-cfn.yml
+++ b/cfn-templates/cid-cfn.yml
@@ -432,6 +432,11 @@ Resources:
           - Id: DeleteContent
             Status: 'Enabled'
             ExpirationInDays: 7
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W3045 # Consider using AWS::S3::BucketPolicy instead of AccessControl
+            reason: "Standard setup for Athena results bucket"
 
   MyAthenaWorkGroup:
     Type: AWS::Athena::WorkGroup

--- a/cfn-templates/cid-cfn.yml
+++ b/cfn-templates/cid-cfn.yml
@@ -433,10 +433,10 @@ Resources:
             Status: 'Enabled'
             ExpirationInDays: 7
     Metadata:
-      cfn_nag:
-        rules_to_suppress:
-          - id: W3045 # Consider using AWS::S3::BucketPolicy instead of AccessControl
-            reason: "Standard setup for Athena results bucket"
+      cfn-lint:
+        config:
+          ignore_checks:
+            - W3045 #Consider using AWS::S3::BucketPolicy instead of AccessControl; standard Athena results setup
 
   MyAthenaWorkGroup:
     Type: AWS::Athena::WorkGroup


### PR DESCRIPTION
Minor edits to names of policies needed for the QS Data Source role to avoid collision.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
