### PR TITLE
Terraform: S3 object tags and fix for continous drift with KMS-encrypted bucket

### DIFF
--- a/terraform-modules/README.md
+++ b/terraform-modules/README.md
@@ -171,8 +171,8 @@ used `stack_parameters`.
 module "cid_dashboards" {
     source = "github.com/aws-samples/aws-cudos-framework-deployment//terraform-modules/cid-dashboards"
 
-    stack_name       = "Cloud-Intelligence-Dashboards"
-    template_bucket  = "UPDATEME" # Update with 
+    stack_name      = "Cloud-Intelligence-Dashboards"
+    template_bucket = "UPDATEME" # Update with S3 bucket name
     stack_parameters = {
       "PrerequisitesQuickSight"            = "yes"
       "PrerequisitesQuickSightPermissions" = "yes"

--- a/terraform-modules/cid-dashboards/README.md
+++ b/terraform-modules/cid-dashboards/README.md
@@ -16,8 +16,9 @@ resources and a custom Lambda function to create the dashboards using `cid-cmd`.
 module "cid_dashboards" {
     source = "github.com/aws-samples/aws-cudos-framework-deployment//terraform-modules/cid-dashboards"
 
-    stack_name       = "Cloud-Intelligence-Dashboards"
-    template_bucket  = "UPDATEME"
+    stack_name      = "Cloud-Intelligence-Dashboards"
+    template_bucket = "UPDATEME"
+  
     stack_parameters = {
       "PrerequisitesQuickSight"            = "yes"
       "PrerequisitesQuickSightPermissions" = "yes"

--- a/terraform-modules/cid-dashboards/main.tf
+++ b/terraform-modules/cid-dashboards/main.tf
@@ -7,6 +7,7 @@ resource "aws_s3_object" "template" {
   key         = var.template_key
   source      = "${path.module}/../../cfn-templates/cid-cfn.yml"
   source_hash = filemd5("${path.module}/../../cfn-templates/cid-cfn.yml")
+  tags        = var.stack_tags
 }
 
 resource "aws_cloudformation_stack" "cid" {

--- a/terraform-modules/cid-dashboards/main.tf
+++ b/terraform-modules/cid-dashboards/main.tf
@@ -3,15 +3,15 @@ data "aws_s3_bucket" "template_bucket" {
 }
 
 resource "aws_s3_object" "template" {
-  bucket = data.aws_s3_bucket.template_bucket.bucket
-  key    = var.template_key
-  source = "${path.module}/../../cfn-templates/cid-cfn.yml"
-  etag   = filemd5("${path.module}/../../cfn-templates/cid-cfn.yml")
+  bucket      = data.aws_s3_bucket.template_bucket.bucket
+  key         = var.template_key
+  source      = "${path.module}/../../cfn-templates/cid-cfn.yml"
+  source_hash = filemd5("${path.module}/../../cfn-templates/cid-cfn.yml")
 }
 
 resource "aws_cloudformation_stack" "cid" {
   name         = var.stack_name
-  template_url = "https://${data.aws_s3_bucket.template_bucket.bucket_regional_domain_name}/${aws_s3_object.template.key}?etag=${aws_s3_object.template.etag}"
+  template_url = "https://${data.aws_s3_bucket.template_bucket.bucket_regional_domain_name}/${aws_s3_object.template.key}?hash=${aws_s3_object.template.source_hash}"
   capabilities = ["CAPABILITY_NAMED_IAM"]
   parameters   = var.stack_parameters
   iam_role_arn = var.stack_iam_role

--- a/terraform-modules/cur-setup-source/main.tf
+++ b/terraform-modules/cur-setup-source/main.tf
@@ -150,7 +150,7 @@ data "aws_iam_policy_document" "s3_assume_role" {
     effect = "Allow"
 
     principals {
-      type        = "Service"
+      type = "Service"
       identifiers = [
         "s3.amazonaws.com",
         "batchoperations.s3.amazonaws.com",
@@ -196,7 +196,7 @@ resource "aws_iam_role" "replication" {
   path               = "/${var.resource_prefix}/"
   assume_role_policy = data.aws_iam_policy_document.s3_assume_role.json
   inline_policy {
-    name = "S3Replication"
+    name   = "S3Replication"
     policy = data.aws_iam_policy_document.replication.json
   }
 }


### PR DESCRIPTION
*Issue #, if available:* #650 #659

*Description of changes:*

Adds template tags to S3 object and fixes issue of continual drift when using KMS default server-side encryption configuration on the S3 `template_bucket`. The etag of objects encrypted with SSE-C or SSE-KMS is not set to the MD5 hash of the object (https://docs.aws.amazon.com/AmazonS3/latest/API/API_Object.html). Terraform instead exposes a `source_hash` used to trigger re-uploads of the S3 objects to work around this issue with the etag.

I've also included tests that plan operations immediately after `terraform apply` do not result in changes when using default settings and when using KMS encryption.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
