### PR TITLE
fix: add glue:GetPartition action to QuickSightDataSourceRole

### DIFF
--- a/cfn-templates/cid-cfn.yml
+++ b/cfn-templates/cid-cfn.yml
@@ -1056,6 +1056,7 @@ Resources:
                               # Cannot restrict this. See https://docs.aws.amazon.com/athena/latest/ug/datacatalogs-example-policies.html#datacatalog-policy-listing-data-catalogs
               - Effect: Allow
                 Action:
+                  - glue:GetPartition
                   - glue:GetPartitions
                   - glue:GetDatabases
                   - glue:GetTable


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/aws-cudos-framework-deployment/issues/705

*Description of changes:*
Adds permissions for glue:GetPartition to the QuickSightDataSourceRole so that the `data_transfer_view` dataset can be added successfully

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
