### PR TITLE
Fix QuickSight dataset refresh schedule creation for hourly_view and resource_view

### DIFF
--- a/cid/builtin/core/data/resources.yaml
+++ b/cid/builtin/core/data/resources.yaml
@@ -158,16 +158,16 @@ datasets:
       views:
         - hourly_view
         - account_map
-      schedules:
-        - default
+    schedules:
+      - default
   resource_view:
     File: cudos/resource_view.json
     dependsOn:
       views:
         - resource_view
         - account_map
-      schedules:
-        - default
+    schedules:
+      - default
   # KPI DataSets
   kpi_ebs_snap:
     File: kpi/kpi_ebs_snap.json


### PR DESCRIPTION
*Issue #, if available:*
1. The QuickSight dataset refresh schedules were not being created for the hourly_view and resource_view datasets.
2. The 'schedules' parameter for these datasets in python/cid/builtin/core/data/resource.yaml was misaligned.

*Description of changes:*
1. Updated the 'schedules' parameter for hourly_view and resource_view in resource.yaml to align properly.
2. This fix should resolve the dataset refresh scheduling issue for hourly_view and resource_view.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
