### PR TITLE
Add force schedule param

### DIFF
--- a/cid/cli.py
+++ b/cid/cli.py
@@ -105,6 +105,7 @@ def csv2view(ctx, **kwargs):
 @click.option('-y', '--yes', help='confirm all', is_flag=True, default=False)
 @click.option('--share-with-account', help='Share dashboard with all users in the current account', is_flag=True, default=None)
 @click.option('--quicksight-delete-failed-datasource', help='Delete datasoruce if creation failed', is_flag=True, default=None)
+@click.option('--force_schedule', help='Tries to schedule Dataset refresh (newly created) without checking previous schedule', is_flag=True, default=None)
 @cid_command
 def deploy(ctx, **kwargs):
     """Deploy Dashboard

--- a/cid/common.py
+++ b/cid/common.py
@@ -4,6 +4,7 @@ import json
 import urllib
 import logging
 import functools
+import re
 from pathlib import Path
 from string import Template
 from typing import Dict
@@ -1229,11 +1230,18 @@ class Cid():
         }.get(asset_type)
         data = None
         file_name = definition.get('File')
-        if definition.get('Data'):
+        _skip = False
+
+        # detect if it's a file or a sql statement
+        if file_name and re.search('select', file_name, re.IGNORECASE) and re.search('from', file_name, re.IGNORECASE):
+            data = file_name
+            _skip = True
+
+        if definition.get('Data') and not _skip:
             data = definition.get('Data')
-        elif definition.get('data'):
+        elif definition.get('data') and not _skip:
             data = definition.get('data')
-        elif file_name:
+        elif file_name and not _skip:
             text = resource_string(
                 definition.get('providedBy'), f'data/{subfolder}/{file_name}'
             ).decode('utf-8')

--- a/cid/common.py
+++ b/cid/common.py
@@ -1074,7 +1074,7 @@ class Cid():
         return dashboard_id
 
 
-    def create_datasets(self, _datasets: list, known_datasets: dict={}, recursive: bool=True, update: bool=False) -> dict:
+    def create_datasets(self, _datasets: list, known_datasets: dict={}, recursive: bool=True, update: bool=False, force_schedule: bool=False) -> dict:
         # Check dependencies
         required_datasets = sorted(_datasets)
         print('\nRequired datasets: \n - {}\n'.format('\n - '.join(list(set(required_datasets)))))
@@ -1121,7 +1121,7 @@ class Cid():
                     logger.critical(e, exc_info=True)
                     raise
                 try:
-                    if self.create_or_update_dataset(dataset_definition, dataset_id, recursive=recursive, update=update):
+                    if self.create_or_update_dataset(dataset_definition, dataset_id, recursive=recursive, update=update, force_schedule=force_schedule):
                         print(f'Updated dataset: "{dataset_name}"')
                     else:
                         print(f'Dataset "{dataset_name}" update failed, collect debug log for more info')
@@ -1176,7 +1176,7 @@ class Cid():
                     logger.critical(e, exc_info=True)
                     raise
                 try:
-                    if self.create_or_update_dataset(dataset_definition, dataset_id, recursive=recursive, update=update):
+                    if self.create_or_update_dataset(dataset_definition, dataset_id, recursive=recursive, update=update, force_schedule=force_schedule):
                         missing_datasets.remove(dataset_name)
                         print(f'Dataset "{dataset_name}" created')
                     else:
@@ -1268,7 +1268,7 @@ class Cid():
 
 
 
-    def create_or_update_dataset(self, dataset_definition: dict, dataset_id: str=None,recursive: bool=True, update: bool=False) -> bool:
+    def create_or_update_dataset(self, dataset_definition: dict, dataset_id: str=None,recursive: bool=True, update: bool=False, force_schedule: bool=False) -> bool:
         # Read dataset definition from template
         data = self.get_data_from_definition('dataset', dataset_definition)
         template = Template(json.dumps(data))
@@ -1467,7 +1467,7 @@ class Cid():
                     schedules_definitions = []
                     for schedule_name in dataset_definition.get('schedules', []):
                         schedules_definitions.append(self.get_definition("schedule", name=schedule_name))
-                        self.qs.ensure_dataset_refresh_schedule(dataset_id, schedules_definitions)
+                        self.qs.ensure_dataset_refresh_schedule(dataset_id, schedules_definitions, force_schedule)
             else:
                 print(f'No update requested for dataset {compiled_dataset.get("DataSetId")} {compiled_dataset.get("Name")}={found_dataset.name} ')
         else:
@@ -1476,7 +1476,7 @@ class Cid():
                 schedules_definitions = []
                 for schedule_name in dataset_definition.get('schedules', []):
                     schedules_definitions.append(self.get_definition("schedule", name=schedule_name))
-                    self.qs.ensure_dataset_refresh_schedule(dataset_id, schedules_definitions)
+                    self.qs.ensure_dataset_refresh_schedule(dataset_id, schedules_definitions, force_schedule)
         return True
 
 

--- a/cid/common.py
+++ b/cid/common.py
@@ -496,7 +496,7 @@ class Cid():
             recursive = True
 
         if recursive:
-            self.create_datasets(required_datasets_names, dashboard_datasets, recursive=recursive, update=update)
+            self.create_datasets(required_datasets_names, dashboard_datasets, recursive=recursive, update=update, force_schedule=kwargs.get("force_schedule", False))
 
         # Find datasets for template or definition
         if not dashboard_definition.get('datasets'):

--- a/cid/helpers/quicksight/__init__.py
+++ b/cid/helpers/quicksight/__init__.py
@@ -1119,18 +1119,21 @@ class QuickSight(CidBase):
             raise CidError(f'Unable to list refresh schedules for dataset {dataset_id}: {str(exc)}') from exc
 
 
-    def ensure_dataset_refresh_schedule(self, dataset_id, schedules: list):
+    def ensure_dataset_refresh_schedule(self, dataset_id, schedules: list, force_schedule=False):
         """ Ensures that dataset has scheduled refresh """
         # get all existing schedules for the given dataset
-        try:
-            existing_schedules = self.get_dataset_refresh_schedules(dataset_id)
-        except CidError as exc:
-            logger.debug(f'List refresh schedule throws: {exc}')
-            logger.warning(
-                f'Cannot read dataset schedules for dataset = {dataset_id}. {str(exc)}. Skipping schedule management.'
-                ' Please make sure scheduled refresh is configured manually.'
-            )
-            return
+        if not force_schedule:
+            try:
+                existing_schedules = self.get_dataset_refresh_schedules(dataset_id)
+            except CidError as exc:
+                logger.debug(f'List refresh schedule throws: {exc}')
+                logger.warning(
+                    f'Cannot read dataset schedules for dataset = {dataset_id}. {str(exc)}. Skipping schedule management.'
+                    ' Please make sure scheduled refresh is configured manually.'
+                )
+                return
+        else:
+            existing_schedules = []
 
         if schedules:
             if exec_env()['terminal'] in ('lambda'):


### PR DESCRIPTION
*Description of changes:* Adds a feature of an optional flag --force_schedule to not check listed schedules for refresh dataset prior to schedule a new one. It only works for dataset created by cid-cmd. It might be useful for IAM with partial permissions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
