### PR TITLE
Update last_kpi_tracker_view.sql

### DIFF
--- a/cid/builtin/core/data/queries/kpi/last_kpi_tracker_view.sql
+++ b/cid/builtin/core/data/queries/kpi/last_kpi_tracker_view.sql
@@ -190,5 +190,5 @@ LEFT JOIN (
    FROM
      kpi_s3_storage_all
    GROUP BY 1, 2, 3
-)  s3_all ON ((s3_all.linked_account_id = account_id) AND (s3_all.billing_period = spend_all.billing_period) AND (s3_all.payer_account_id=spend_all.payer_account_id)))
+)  s3_all ON ((s3_all.linked_account_id = account_id) AND (s3_all.billing_period = spend_all.billing_period) AND (s3_all.payer_account_id = spend_all.payer_account_id)))
 WHERE (spend_all.billing_period >= ("date_trunc"('month', current_timestamp) - INTERVAL  '3' MONTH))

--- a/cid/builtin/core/data/queries/kpi/last_kpi_tracker_view.sql
+++ b/cid/builtin/core/data/queries/kpi/last_kpi_tracker_view.sql
@@ -166,7 +166,7 @@ LEFT JOIN (
    FROM
      kpi_ebs_storage_all
    GROUP BY 1, 2, 3
-)  ebs_all ON ((ebs_all.linked_account_id = account_id) AND (ebs_all.billing_period = spend_all.billing_period) AND (ebs_all.payer_account_id= spend_all.payer_account_id)))
+)  ebs_all ON ((ebs_all.linked_account_id = account_id) AND (ebs_all.billing_period = spend_all.billing_period) AND (ebs_all.payer_account_id = spend_all.payer_account_id)))
 LEFT JOIN (
    SELECT DISTINCT
      billing_period

--- a/cid/builtin/core/data/queries/kpi/last_kpi_tracker_view.sql
+++ b/cid/builtin/core/data/queries/kpi/last_kpi_tracker_view.sql
@@ -1,4 +1,3 @@
-
 CREATE OR REPLACE VIEW kpi_tracker AS 
 SELECT DISTINCT
 spend_all.billing_period
@@ -87,7 +86,7 @@ LEFT JOIN (
      summary_view
    WHERE (CAST("concat"("year", '-', "month", '-01') AS date) >= ("date_trunc"('month', current_date) - INTERVAL  '3' MONTH))
    GROUP BY 1, 2, 3
-)  spend_all ON (spend_all.linked_account_id = account_id))
+)  spend_all ON (spend_all.linked_account_id = account_id) AND (spend_all.payer_account_id = payer_account_id))
 LEFT JOIN (
    SELECT DISTINCT
      billing_period
@@ -153,7 +152,7 @@ LEFT JOIN (
    FROM
      kpi_instance_all
    GROUP BY 1, 2, 3
-)  instance_all ON ((instance_all.linked_account_id = account_id) AND (instance_all.billing_period = spend_all.billing_period)))
+)  instance_all ON ((instance_all.linked_account_id = account_id) AND (instance_all.billing_period = spend_all.billing_period) AND (instance_all.payer_account_id = spend_all.payer_account_id)))
 LEFT JOIN (
    SELECT DISTINCT
      billing_period
@@ -167,7 +166,7 @@ LEFT JOIN (
    FROM
      kpi_ebs_storage_all
    GROUP BY 1, 2, 3
-)  ebs_all ON ((ebs_all.linked_account_id = account_id) AND (ebs_all.billing_period = spend_all.billing_period)))
+)  ebs_all ON ((ebs_all.linked_account_id = account_id) AND (ebs_all.billing_period = spend_all.billing_period) AND (ebs_all.payer_account_id= spend_all.payer_account_id)))
 LEFT JOIN (
    SELECT DISTINCT
      billing_period
@@ -179,7 +178,7 @@ LEFT JOIN (
    FROM
      kpi_ebs_snap
    GROUP BY 1, 2, 3
-)  snap ON ((snap.linked_account_id = account_id) AND (snap.billing_period = spend_all.billing_period)))
+)  snap ON ((snap.linked_account_id = account_id) AND (snap.billing_period = spend_all.billing_period) AND (snap.payer_account_id = spend_all.payer_account_id)))
 LEFT JOIN (
    SELECT DISTINCT
      billing_period
@@ -191,5 +190,5 @@ LEFT JOIN (
    FROM
      kpi_s3_storage_all
    GROUP BY 1, 2, 3
-)  s3_all ON ((s3_all.linked_account_id = account_id) AND (s3_all.billing_period = spend_all.billing_period)))
+)  s3_all ON ((s3_all.linked_account_id = account_id) AND (s3_all.billing_period = spend_all.billing_period) AND (s3_all.payer_account_id=spend_all.payer_account_id)))
 WHERE (spend_all.billing_period >= ("date_trunc"('month', current_timestamp) - INTERVAL  '3' MONTH))


### PR DESCRIPTION
Added PayerID joining condition in line 89,155,169,181 & 193

This is to fix duplicate linked account data in the scenario where a linked account is moved from one org to other.

*Issue #, if available:* Duplicate Linked account data

This is to cover the scenario where a linked account moves to another payer and we also have its historical cur data linked with its previous payer account, in that case we will have duplicate linked account as a result of our query which is causing this issue. To avoid that we can also include payerid with accountid so that we get distinct results for each payer and its linked account.

*Description of changes:*

Added PayerID in joining conditions to fix it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
