### PR TITLE
Adding EKS Extended Support Cost Projection dashboard definition

### DIFF
--- a/dashboards/extended-support-cost-projection/extended-support-cost-projection.yaml
+++ b/dashboards/extended-support-cost-projection/extended-support-cost-projection.yaml
@@ -6,7 +6,7 @@ dashboards:
       - rds_extended_support_view
     name: Extended Support Cost Projection
     dashboardId: extended-support-cost-projection
-    category: Custom
+    category: Advanced
     data: |-
       AnalysisDefaults:
         DefaultNewSheetConfiguration:
@@ -2857,7 +2857,18 @@ dashboards:
               Visibility: VISIBLE
             VisualId: fc3ac4a1-b895-4e78-9b39-938b7ffd415e
         - TableVisual:
-            Actions: []
+            Actions:
+            - ActionOperations:
+              - FilterOperation:
+                  SelectedFieldsConfiguration:
+                    SelectedFieldOptions: ALL_FIELDS
+                  TargetVisualsConfiguration:
+                    SameSheetTargetVisualConfiguration:
+                      TargetVisualOptions: ALL_VISUALS
+              CustomActionId: e163ff8d-f884-4a23-920f-703c2d4e26af
+              Name: Action 1
+              Status: ENABLED
+              Trigger: DATA_POINT_CLICK
             ChartConfiguration:
               FieldOptions:
                 Order: []
@@ -2890,6 +2901,8 @@ dashboards:
                   Values: []
               SortConfiguration: {}
               TableOptions:
+                CellStyle:
+                  Height: 25
                 HeaderStyle:
                   Height: 25
                   TextWrap: WRAP

--- a/dashboards/extended-support-cost-projection/extended-support-cost-projection.yaml
+++ b/dashboards/extended-support-cost-projection/extended-support-cost-projection.yaml
@@ -19,28 +19,28 @@ dashboards:
           SheetContentType: INTERACTIVE
       CalculatedFields:
       - DataSetIdentifier: eks_extended_support_view
-        Expression: (100 - ${EDPDiscount})/100
-        Name: EDP_Discount_Factor
+        Expression: (100 - ${Discount})/100
+        Name: Discount_Factor
       - DataSetIdentifier: eks_extended_support_view
-        Expression: '{EDP_Discount_Factor} * {usage_amount} * 0.6'
+        Expression: '{Discount_Factor} * {usage_amount} * 0.6'
         Name: Estimated_Extended_Support_Monthly_Cost
       - DataSetIdentifier: eks_extended_support_view
         Expression: dateDiff(now(), {start_of_extended_support}, 'MM')
         Name: Months_Before_Start_Ext_Supp
       - DataSetIdentifier: rds_extended_support_view
-        Expression: '{EDP_Discount_Factor} * {year_1_2_cost}'
+        Expression: '{Discount_Factor} * {year_1_2_cost}'
         Name: Actual_Year_1_2_Cost
       - DataSetIdentifier: rds_extended_support_view
-        Expression: '{EDP_Discount_Factor} * {year_3_cost}'
+        Expression: '{Discount_Factor} * {year_3_cost}'
         Name: Actual_Year_3_Cost
       - DataSetIdentifier: rds_extended_support_view
-        Expression: (100 - ${EDPDiscount})/100
-        Name: EDP_Discount_Factor
+        Expression: (100 - ${Discount})/100
+        Name: Discount_Factor
       - DataSetIdentifier: rds_extended_support_view
-        Expression: '{EDP_Discount_Factor} * {vcpu_acu_hours} * {year_1_2_pricing}'
+        Expression: '{Discount_Factor} * {vcpu_acu_hours} * {year_1_2_pricing}'
         Name: Estimated_Year_1_2_Cost
       - DataSetIdentifier: rds_extended_support_view
-        Expression: '{EDP_Discount_Factor} * {vcpu_acu_hours} * {Year_3_Pricing_Fallback}'
+        Expression: '{Discount_Factor} * {vcpu_acu_hours} * {Year_3_Pricing_Fallback}'
         Name: Estimated_Year_3_Cost
       - DataSetIdentifier: rds_extended_support_view
         Expression: dateDiff(now(), {year_1_start}, 'MM')
@@ -733,7 +733,7 @@ dashboards:
           DefaultValues:
             StaticValues:
             - 0.0
-          Name: EDPDiscount
+          Name: Discount
           ParameterValueType: SINGLE_VALUED
           ValueWhenUnset:
             ValueWhenUnsetOption: RECOMMENDED_VALUE

--- a/dashboards/extended-support-cost-projection/extended-support-cost-projection.yaml
+++ b/dashboards/extended-support-cost-projection/extended-support-cost-projection.yaml
@@ -2,10 +2,11 @@ dashboards:
   EXTENDED SUPPORT COST PROJECTION:
     dependsOn:
       datasets:
+      - eks_extended_support_view
       - rds_extended_support_view
     name: Extended Support Cost Projection
     dashboardId: extended-support-cost-projection
-    category: Advanced
+    category: Custom
     data: |-
       AnalysisDefaults:
         DefaultNewSheetConfiguration:
@@ -17,6 +18,15 @@ dashboards:
                   ResizeOption: FIXED
           SheetContentType: INTERACTIVE
       CalculatedFields:
+      - DataSetIdentifier: eks_extended_support_view
+        Expression: (100 - ${EDPDiscount})/100
+        Name: EDP_Discount_Factor
+      - DataSetIdentifier: eks_extended_support_view
+        Expression: '{EDP_Discount_Factor} * {usage_amount} * 0.6'
+        Name: Estimated_Extended_Support_Monthly_Cost
+      - DataSetIdentifier: eks_extended_support_view
+        Expression: dateDiff(now(), {start_of_extended_support}, 'MM')
+        Name: Months_Before_Start_Ext_Supp
       - DataSetIdentifier: rds_extended_support_view
         Expression: '{EDP_Discount_Factor} * {year_1_2_cost}'
         Name: Actual_Year_1_2_Cost
@@ -63,7 +73,7 @@ dashboards:
                     Visibility: VISIBLE
                 Symbol: USD
       - Column:
-          ColumnName: Estimated_Year_1_2_Cost
+          ColumnName: Actual_Year_1_2_Cost
           DataSetIdentifier: rds_extended_support_view
         FormatConfiguration:
           NumberFormatConfiguration:
@@ -83,7 +93,7 @@ dashboards:
                     Visibility: VISIBLE
                 Symbol: USD
       - Column:
-          ColumnName: Estimated_Year_3_Cost
+          ColumnName: Estimated_Year_1_2_Cost
           DataSetIdentifier: rds_extended_support_view
         FormatConfiguration:
           NumberFormatConfiguration:
@@ -190,8 +200,38 @@ dashboards:
                     Visibility: VISIBLE
                 Symbol: USD
       - Column:
-          ColumnName: Actual_Year_1_2_Cost
+          ColumnName: Estimated_Year_3_Cost
           DataSetIdentifier: rds_extended_support_view
+        FormatConfiguration:
+          NumberFormatConfiguration:
+            FormatConfiguration:
+              CurrencyDisplayFormatConfiguration:
+                DecimalPlacesConfiguration:
+                  DecimalPlaces: 3
+                NegativeValueConfiguration:
+                  DisplayMode: POSITIVE
+                NullValueFormatConfiguration:
+                  NullString: 'null'
+                NumberScale: AUTO
+                SeparatorConfiguration:
+                  DecimalSeparator: DOT
+                  ThousandsSeparator:
+                    Symbol: COMMA
+                    Visibility: VISIBLE
+                Symbol: USD
+      - Column:
+          ColumnName: usage_amount
+          DataSetIdentifier: eks_extended_support_view
+        FormatConfiguration:
+          NumberFormatConfiguration:
+            FormatConfiguration:
+              NumberDisplayFormatConfiguration:
+                NullValueFormatConfiguration:
+                  NullString: 'null'
+                NumberScale: AUTO
+      - Column:
+          ColumnName: Estimated_Extended_Support_Monthly_Cost
+          DataSetIdentifier: eks_extended_support_view
         FormatConfiguration:
           NumberFormatConfiguration:
             FormatConfiguration:
@@ -212,6 +252,8 @@ dashboards:
       DataSetIdentifierDeclarations:
       - DataSetArn: arn:aws:quicksight:::dataset/31961243-0137-4201-a8d1-c2a00755765e
         Identifier: rds_extended_support_view
+      - DataSetArn: arn:aws:quicksight:::dataset/321e897c-7912-4cfd-bd4c-d15d0f948127
+        Identifier: eks_extended_support_view
       FilterGroups:
       - CrossDataset: SINGLE_DATASET
         FilterGroupId: 2f17da6a-9382-4592-95af-15eec49e9596
@@ -230,9 +272,9 @@ dashboards:
           SelectedSheets:
             SheetVisualScopingConfigurations:
             - Scope: SELECTED_VISUALS
-              SheetId: 43a88b3c-2e23-44b9-b361-41a48a65601b
+              SheetId: bde3deaa-1754-4d65-bbd9-48139b6e9bc8
               VisualIds:
-              - 9afc5e06-b00e-4345-8690-7424211c9bc5
+              - 02bf7f90-4e6b-4552-b672-691fd05798da
         Status: ENABLED
       - CrossDataset: SINGLE_DATASET
         FilterGroupId: cf3e70f5-978c-4302-a173-fdbe932e7c5c
@@ -251,9 +293,9 @@ dashboards:
           SelectedSheets:
             SheetVisualScopingConfigurations:
             - Scope: SELECTED_VISUALS
-              SheetId: 43a88b3c-2e23-44b9-b361-41a48a65601b
+              SheetId: bde3deaa-1754-4d65-bbd9-48139b6e9bc8
               VisualIds:
-              - c5e5be1f-820f-49a5-9694-28062f430e15
+              - 34920740-d251-4b16-91f1-65ba6fa9c7d6
         Status: ENABLED
       - CrossDataset: SINGLE_DATASET
         FilterGroupId: 833b8c86-9766-4b99-a5fb-ba3e4ef8d08c
@@ -272,9 +314,9 @@ dashboards:
           SelectedSheets:
             SheetVisualScopingConfigurations:
             - Scope: SELECTED_VISUALS
-              SheetId: 43a88b3c-2e23-44b9-b361-41a48a65601b
+              SheetId: bde3deaa-1754-4d65-bbd9-48139b6e9bc8
               VisualIds:
-              - 67d086cc-0f88-41bc-9f93-5d464afc0bc8
+              - 2fde338f-7f53-43b0-accb-e474f8b5b55e
         Status: ENABLED
       - CrossDataset: SINGLE_DATASET
         FilterGroupId: 215e6218-84f1-4f2d-a089-2724f513dac4
@@ -293,9 +335,9 @@ dashboards:
           SelectedSheets:
             SheetVisualScopingConfigurations:
             - Scope: SELECTED_VISUALS
-              SheetId: 43a88b3c-2e23-44b9-b361-41a48a65601b
+              SheetId: bde3deaa-1754-4d65-bbd9-48139b6e9bc8
               VisualIds:
-              - c5e5be1f-820f-49a5-9694-28062f430e15
+              - 34920740-d251-4b16-91f1-65ba6fa9c7d6
         Status: ENABLED
       - CrossDataset: SINGLE_DATASET
         FilterGroupId: 2fe3bdea-f9d9-4376-8c5a-774089117858
@@ -314,9 +356,9 @@ dashboards:
           SelectedSheets:
             SheetVisualScopingConfigurations:
             - Scope: SELECTED_VISUALS
-              SheetId: 43a88b3c-2e23-44b9-b361-41a48a65601b
+              SheetId: bde3deaa-1754-4d65-bbd9-48139b6e9bc8
               VisualIds:
-              - 67d086cc-0f88-41bc-9f93-5d464afc0bc8
+              - 2fde338f-7f53-43b0-accb-e474f8b5b55e
         Status: ENABLED
       - CrossDataset: SINGLE_DATASET
         FilterGroupId: bd90bee7-53ae-4185-ac0b-e63f97e3b866
@@ -335,9 +377,9 @@ dashboards:
           SelectedSheets:
             SheetVisualScopingConfigurations:
             - Scope: SELECTED_VISUALS
-              SheetId: 43a88b3c-2e23-44b9-b361-41a48a65601b
+              SheetId: bde3deaa-1754-4d65-bbd9-48139b6e9bc8
               VisualIds:
-              - c2f68c74-7dbe-4034-bc5c-ac709565220e
+              - 85b93569-fc85-45ee-b657-2c97518b4288
         Status: ENABLED
       - CrossDataset: SINGLE_DATASET
         FilterGroupId: aa73eee4-f3c4-41d7-952a-00cd2105a67b
@@ -356,7 +398,7 @@ dashboards:
           SelectedSheets:
             SheetVisualScopingConfigurations:
             - Scope: ALL_VISUALS
-              SheetId: 43a88b3c-2e23-44b9-b361-41a48a65601b
+              SheetId: bde3deaa-1754-4d65-bbd9-48139b6e9bc8
         Status: ENABLED
       - CrossDataset: SINGLE_DATASET
         FilterGroupId: f36e0a01-2cd0-43b2-9719-bea89d5b859d
@@ -375,7 +417,7 @@ dashboards:
           SelectedSheets:
             SheetVisualScopingConfigurations:
             - Scope: ALL_VISUALS
-              SheetId: 43a88b3c-2e23-44b9-b361-41a48a65601b
+              SheetId: bde3deaa-1754-4d65-bbd9-48139b6e9bc8
         Status: ENABLED
       - CrossDataset: SINGLE_DATASET
         FilterGroupId: 33846fa0-92dd-4779-a51d-6b50879a332a
@@ -397,7 +439,292 @@ dashboards:
           SelectedSheets:
             SheetVisualScopingConfigurations:
             - Scope: ALL_VISUALS
-              SheetId: 43a88b3c-2e23-44b9-b361-41a48a65601b
+              SheetId: bde3deaa-1754-4d65-bbd9-48139b6e9bc8
+        Status: ENABLED
+      - CrossDataset: SINGLE_DATASET
+        FilterGroupId: e3a444dd-8196-4b96-afb2-8467b41edaac
+        Filters:
+        - CategoryFilter:
+            Column:
+              ColumnName: payer_account_id
+              DataSetIdentifier: rds_extended_support_view
+            Configuration:
+              CustomFilterConfiguration:
+                MatchOperator: EQUALS
+                NullOption: NON_NULLS_ONLY
+                ParameterName: Payer
+            FilterId: 25d280f1-ae1d-4550-af8a-ced78c16929e
+        ScopeConfiguration:
+          SelectedSheets:
+            SheetVisualScopingConfigurations:
+            - Scope: ALL_VISUALS
+              SheetId: 388ea71f-ce1e-4725-8900-c8b552f3bbd4
+        Status: ENABLED
+      - CrossDataset: SINGLE_DATASET
+        FilterGroupId: 690def29-0236-4b47-bc6f-5b829189b3d8
+        Filters:
+        - CategoryFilter:
+            Column:
+              ColumnName: linked_account_id
+              DataSetIdentifier: rds_extended_support_view
+            Configuration:
+              CustomFilterConfiguration:
+                MatchOperator: EQUALS
+                NullOption: NON_NULLS_ONLY
+                ParameterName: LinkedAccount
+            FilterId: a8f03cf7-6525-4df9-b947-73009844de7b
+        ScopeConfiguration:
+          SelectedSheets:
+            SheetVisualScopingConfigurations:
+            - Scope: ALL_VISUALS
+              SheetId: 388ea71f-ce1e-4725-8900-c8b552f3bbd4
+        Status: ENABLED
+      - CrossDataset: SINGLE_DATASET
+        FilterGroupId: 0205bf7f-6cd5-4f55-8d84-204fae79fb95
+        Filters:
+        - TimeRangeFilter:
+            Column:
+              ColumnName: usage_date
+              DataSetIdentifier: rds_extended_support_view
+            FilterId: 4bfd988d-5493-4658-9eb4-e31d37c8c48e
+            IncludeMaximum: true
+            IncludeMinimum: true
+            NullOption: NON_NULLS_ONLY
+            RangeMaximumValue:
+              Parameter: EndDate
+            RangeMinimumValue:
+              Parameter: StartDate
+            TimeGranularity: DAY
+        ScopeConfiguration:
+          SelectedSheets:
+            SheetVisualScopingConfigurations:
+            - Scope: ALL_VISUALS
+              SheetId: 388ea71f-ce1e-4725-8900-c8b552f3bbd4
+        Status: ENABLED
+      - CrossDataset: SINGLE_DATASET
+        FilterGroupId: c05373a5-2c9c-4092-bd59-70dbbb51fe0e
+        Filters:
+        - CategoryFilter:
+            Column:
+              ColumnName: payer_account_id
+              DataSetIdentifier: eks_extended_support_view
+            Configuration:
+              CustomFilterConfiguration:
+                MatchOperator: EQUALS
+                NullOption: NON_NULLS_ONLY
+                ParameterName: Payer
+            FilterId: 2d548978-b52d-4a24-aac7-9d95b983b6c5
+        ScopeConfiguration:
+          SelectedSheets:
+            SheetVisualScopingConfigurations:
+            - Scope: ALL_VISUALS
+              SheetId: 388ea71f-ce1e-4725-8900-c8b552f3bbd4
+        Status: ENABLED
+      - CrossDataset: SINGLE_DATASET
+        FilterGroupId: 0a7aaa7a-7331-4a96-b6b0-22760cfe20f0
+        Filters:
+        - CategoryFilter:
+            Column:
+              ColumnName: linked_account_id
+              DataSetIdentifier: eks_extended_support_view
+            Configuration:
+              CustomFilterConfiguration:
+                MatchOperator: EQUALS
+                NullOption: NON_NULLS_ONLY
+                ParameterName: LinkedAccount
+            FilterId: e107306c-8b85-4fa5-a0eb-30cbd94a34c0
+        ScopeConfiguration:
+          SelectedSheets:
+            SheetVisualScopingConfigurations:
+            - Scope: ALL_VISUALS
+              SheetId: 388ea71f-ce1e-4725-8900-c8b552f3bbd4
+        Status: ENABLED
+      - CrossDataset: SINGLE_DATASET
+        FilterGroupId: ae824035-ab32-4d17-a676-bf2005b3437f
+        Filters:
+        - TimeRangeFilter:
+            Column:
+              ColumnName: usage_date
+              DataSetIdentifier: eks_extended_support_view
+            FilterId: 51e99ef5-5f68-48ab-8c8b-142a0dadbe0a
+            IncludeMaximum: true
+            IncludeMinimum: true
+            NullOption: NON_NULLS_ONLY
+            RangeMaximumValue:
+              Parameter: EndDate
+            RangeMinimumValue:
+              Parameter: StartDate
+            TimeGranularity: DAY
+        ScopeConfiguration:
+          SelectedSheets:
+            SheetVisualScopingConfigurations:
+            - Scope: SELECTED_VISUALS
+              SheetId: 388ea71f-ce1e-4725-8900-c8b552f3bbd4
+              VisualIds:
+              - 3da23b18-432f-4b6a-ab40-7f60b436c3e5
+              - 98f98793-38b7-4f7b-8e87-2a4b7ed33b4a
+              - e8a807d9-a5fb-4efe-8666-18696a37403e
+              - ad1f27dd-f85b-4bb3-872c-b3468ac7ce53
+              - f69eb697-076f-424f-a40c-d9fa915dc8da
+              - 9e962230-38c7-48f1-8782-f7205b5ff259
+              - fc3ac4a1-b895-4e78-9b39-938b7ffd415e
+              - 2f853899-7c87-4c3e-8116-c99ec2f1ce20
+              - 8fff2b3b-2490-4ee1-adbd-e10fa5199940
+              - 43f608d9-e0e4-49c6-bae4-71ea6ebd5a57
+              - 621445ba-935a-43a5-8b12-d6cad2185947
+        Status: ENABLED
+      - CrossDataset: SINGLE_DATASET
+        FilterGroupId: c942fd6b-e51f-4a05-a651-199cb1f9726e
+        Filters:
+        - NumericRangeFilter:
+            Column:
+              ColumnName: Months_Before_Start_Ext_Supp
+              DataSetIdentifier: eks_extended_support_view
+            FilterId: 31dec639-c99e-446a-8d50-4c92c2d5e9b4
+            IncludeMaximum: false
+            IncludeMinimum: false
+            NullOption: ALL_VALUES
+            RangeMaximum:
+              StaticValue: 3.0
+        ScopeConfiguration:
+          SelectedSheets:
+            SheetVisualScopingConfigurations:
+            - Scope: SELECTED_VISUALS
+              SheetId: 388ea71f-ce1e-4725-8900-c8b552f3bbd4
+              VisualIds:
+              - 2f853899-7c87-4c3e-8116-c99ec2f1ce20
+        Status: ENABLED
+      - CrossDataset: SINGLE_DATASET
+        FilterGroupId: fb5f848b-6e24-4eff-9c11-9a81fdc7f455
+        Filters:
+        - NumericRangeFilter:
+            Column:
+              ColumnName: Months_Before_Start_Ext_Supp
+              DataSetIdentifier: eks_extended_support_view
+            FilterId: 02e8ca75-4dcb-4ca9-b186-d83706ed0dc6
+            IncludeMaximum: false
+            IncludeMinimum: true
+            NullOption: ALL_VALUES
+            RangeMinimum:
+              StaticValue: 3.0
+        ScopeConfiguration:
+          SelectedSheets:
+            SheetVisualScopingConfigurations:
+            - Scope: SELECTED_VISUALS
+              SheetId: 388ea71f-ce1e-4725-8900-c8b552f3bbd4
+              VisualIds:
+              - fc3ac4a1-b895-4e78-9b39-938b7ffd415e
+        Status: ENABLED
+      - CrossDataset: SINGLE_DATASET
+        FilterGroupId: 80dc41f6-5c72-401f-9e7e-2398fae1d7d1
+        Filters:
+        - NumericRangeFilter:
+            Column:
+              ColumnName: Months_Before_Start_Ext_Supp
+              DataSetIdentifier: eks_extended_support_view
+            FilterId: cca653aa-4dcb-4df6-86cc-1e915d0fb507
+            IncludeMaximum: false
+            IncludeMinimum: true
+            NullOption: ALL_VALUES
+            RangeMinimum:
+              StaticValue: 6.0
+        ScopeConfiguration:
+          SelectedSheets:
+            SheetVisualScopingConfigurations:
+            - Scope: SELECTED_VISUALS
+              SheetId: 388ea71f-ce1e-4725-8900-c8b552f3bbd4
+              VisualIds:
+              - 9e962230-38c7-48f1-8782-f7205b5ff259
+        Status: ENABLED
+      - CrossDataset: SINGLE_DATASET
+        FilterGroupId: b257166c-4314-461c-9327-736fbf156abf
+        Filters:
+        - NumericRangeFilter:
+            Column:
+              ColumnName: Months_Before_Start_Ext_Supp
+              DataSetIdentifier: eks_extended_support_view
+            FilterId: b97ab2fd-fc3d-40f0-88a8-52a3d51947c5
+            IncludeMaximum: false
+            IncludeMinimum: true
+            NullOption: ALL_VALUES
+            RangeMinimum:
+              StaticValue: 12.0
+        ScopeConfiguration:
+          SelectedSheets:
+            SheetVisualScopingConfigurations:
+            - Scope: SELECTED_VISUALS
+              SheetId: 388ea71f-ce1e-4725-8900-c8b552f3bbd4
+              VisualIds:
+              - f69eb697-076f-424f-a40c-d9fa915dc8da
+        Status: ENABLED
+      - CrossDataset: SINGLE_DATASET
+        FilterGroupId: 2d0cfbf6-40c8-4c50-8cd0-6fe745c71a02
+        Filters:
+        - NumericRangeFilter:
+            Column:
+              ColumnName: Months_Before_Start_Ext_Supp
+              DataSetIdentifier: eks_extended_support_view
+            FilterId: 737f3bf7-15c0-448d-9e4f-b37fac8d9bc2
+            IncludeMaximum: false
+            IncludeMinimum: false
+            NullOption: ALL_VALUES
+            RangeMaximum:
+              StaticValue: 6.0
+        ScopeConfiguration:
+          SelectedSheets:
+            SheetVisualScopingConfigurations:
+            - Scope: SELECTED_VISUALS
+              SheetId: 388ea71f-ce1e-4725-8900-c8b552f3bbd4
+              VisualIds:
+              - fc3ac4a1-b895-4e78-9b39-938b7ffd415e
+        Status: ENABLED
+      - CrossDataset: SINGLE_DATASET
+        FilterGroupId: ac9ca838-1685-4064-8cb8-1f3dd3e04d16
+        Filters:
+        - NumericRangeFilter:
+            Column:
+              ColumnName: Months_Before_Start_Ext_Supp
+              DataSetIdentifier: eks_extended_support_view
+            FilterId: 3b3adbd2-382f-403b-b0cb-96d4569df63d
+            IncludeMaximum: false
+            IncludeMinimum: false
+            NullOption: ALL_VALUES
+            RangeMaximum:
+              StaticValue: 12.0
+        ScopeConfiguration:
+          SelectedSheets:
+            SheetVisualScopingConfigurations:
+            - Scope: SELECTED_VISUALS
+              SheetId: 388ea71f-ce1e-4725-8900-c8b552f3bbd4
+              VisualIds:
+              - 9e962230-38c7-48f1-8782-f7205b5ff259
+        Status: ENABLED
+      - CrossDataset: SINGLE_DATASET
+        FilterGroupId: b5fa5da0-e4d3-4071-be0e-28acb1e1400a
+        Filters:
+        - RelativeDatesFilter:
+            AnchorDateConfiguration:
+              AnchorOption: NOW
+            Column:
+              ColumnName: billing_period
+              DataSetIdentifier: eks_extended_support_view
+            ExcludePeriodConfiguration:
+              Amount: 1
+              Granularity: MONTH
+              Status: DISABLED
+            FilterId: 42060644-a8ef-43ea-9173-6396596ebfbb
+            MinimumGranularity: DAY
+            NullOption: NON_NULLS_ONLY
+            RelativeDateType: LAST
+            RelativeDateValue: 4
+            TimeGranularity: MONTH
+        ScopeConfiguration:
+          SelectedSheets:
+            SheetVisualScopingConfigurations:
+            - Scope: SELECTED_VISUALS
+              SheetId: 388ea71f-ce1e-4725-8900-c8b552f3bbd4
+              VisualIds:
+              - 0c8e79b3-2169-4f73-87de-67ca3116dca1
         Status: ENABLED
       Options:
         WeekStart: SUNDAY
@@ -448,7 +775,7 @@ dashboards:
               Elements:
               - ColumnIndex: 1
                 ColumnSpan: 18
-                ElementId: 34d4af34-269d-42e3-86ad-e616a362fbd6
+                ElementId: 03a6bffd-a356-40cb-a001-130dbb756153
                 ElementType: VISUAL
                 RowIndex: 0
                 RowSpan: 6
@@ -460,67 +787,67 @@ dashboards:
                 RowSpan: 2
               - ColumnIndex: 19
                 ColumnSpan: 4
-                ElementId: 9afc5e06-b00e-4345-8690-7424211c9bc5
+                ElementId: 02bf7f90-4e6b-4552-b672-691fd05798da
                 ElementType: VISUAL
                 RowIndex: 2
                 RowSpan: 4
               - ColumnIndex: 23
                 ColumnSpan: 4
-                ElementId: c5e5be1f-820f-49a5-9694-28062f430e15
+                ElementId: 34920740-d251-4b16-91f1-65ba6fa9c7d6
                 ElementType: VISUAL
                 RowIndex: 2
                 RowSpan: 4
               - ColumnIndex: 27
                 ColumnSpan: 4
-                ElementId: 67d086cc-0f88-41bc-9f93-5d464afc0bc8
+                ElementId: 2fde338f-7f53-43b0-accb-e474f8b5b55e
                 ElementType: VISUAL
                 RowIndex: 2
                 RowSpan: 4
               - ColumnIndex: 31
                 ColumnSpan: 4
-                ElementId: c2f68c74-7dbe-4034-bc5c-ac709565220e
+                ElementId: 85b93569-fc85-45ee-b657-2c97518b4288
                 ElementType: VISUAL
                 RowIndex: 2
                 RowSpan: 4
-              - ColumnIndex: 10
-                ColumnSpan: 9
-                ElementId: bbb4130e-d2e8-4f0f-8c6a-a294dc9bc83a
+              - ColumnIndex: 9
+                ColumnSpan: 10
+                ElementId: 52679c34-14d5-4061-aa17-bf1fc8a51ec2
                 ElementType: VISUAL
                 RowIndex: 6
                 RowSpan: 4
               - ColumnIndex: 19
-                ColumnSpan: 9
-                ElementId: 2ea5b124-a8d3-4311-9da5-98518feeeb95
+                ColumnSpan: 10
+                ElementId: fff8acda-7c74-4eca-8c56-c1e60155803a
                 ElementType: VISUAL
                 RowIndex: 6
                 RowSpan: 4
               - ColumnIndex: 1
                 ColumnSpan: 14
-                ElementId: 416cee8a-0600-4aaa-bb69-350727060b30
+                ElementId: 966e940f-6bda-4007-b15d-e887299acca9
                 ElementType: VISUAL
                 RowIndex: 10
                 RowSpan: 9
               - ColumnIndex: 15
                 ColumnSpan: 20
-                ElementId: 9233cbd6-d6dd-4e29-a059-1895ee909b0c
+                ElementId: d4a36c45-b449-4cae-8862-5cdeba65518c
                 ElementType: VISUAL
                 RowIndex: 10
                 RowSpan: 9
               - ColumnIndex: 1
                 ColumnSpan: 17
-                ElementId: 7c913b40-495d-4f0c-bd2b-585f39e485e8
+                ElementId: 38aac42b-71f9-47f0-bae2-76451c00b700
                 ElementType: VISUAL
                 RowIndex: 19
                 RowSpan: 12
               - ColumnIndex: 18
                 ColumnSpan: 17
-                ElementId: 66220df2-7b74-4e80-9904-aedc3b14870f
+                ElementId: dd71227e-4c4f-4294-a7db-26a7955417c6
                 ElementType: VISUAL
                 RowIndex: 19
                 RowSpan: 12
               - ColumnIndex: 1
                 ColumnSpan: 34
-                ElementId: 3594d0e0-e54e-44ce-8f1f-e50229dc458c
+                ElementId: 7a3e14c3-424d-4883-84b3-2a75b614a878
                 ElementType: VISUAL
                 RowIndex: 31
                 RowSpan: 10
@@ -586,7 +913,7 @@ dashboards:
         - Configuration:
             GridLayout:
               Elements: []
-        SheetId: 43a88b3c-2e23-44b9-b361-41a48a65601b
+        SheetId: bde3deaa-1754-4d65-bbd9-48139b6e9bc8
         TextBoxes:
         - Content: |-
             <text-box>
@@ -703,7 +1030,7 @@ dashboards:
               FormatText:
                 RichText: <visual-title>vCPU/ACU Hours Breakdown - Account by Engine</visual-title>
               Visibility: VISIBLE
-            VisualId: 66220df2-7b74-4e80-9904-aedc3b14870f
+            VisualId: dd71227e-4c4f-4294-a7db-26a7955417c6
         - BarChartVisual:
             Actions: []
             ChartConfiguration:
@@ -799,7 +1126,7 @@ dashboards:
               FormatText:
                 RichText: <visual-title>Estimated Costs by Engine Version</visual-title>
               Visibility: VISIBLE
-            VisualId: 9233cbd6-d6dd-4e29-a059-1895ee909b0c
+            VisualId: d4a36c45-b449-4cae-8862-5cdeba65518c
         - KPIVisual:
             Actions: []
             ChartConfiguration:
@@ -845,7 +1172,7 @@ dashboards:
                     </block>
                   </visual-title>
               Visibility: VISIBLE
-            VisualId: c2f68c74-7dbe-4034-bc5c-ac709565220e
+            VisualId: 85b93569-fc85-45ee-b657-2c97518b4288
         - KPIVisual:
             Actions: []
             ChartConfiguration:
@@ -892,7 +1219,7 @@ dashboards:
                     </block>
                   </visual-title>
               Visibility: VISIBLE
-            VisualId: 67d086cc-0f88-41bc-9f93-5d464afc0bc8
+            VisualId: 2fde338f-7f53-43b0-accb-e474f8b5b55e
         - KPIVisual:
             Actions: []
             ChartConfiguration:
@@ -939,7 +1266,7 @@ dashboards:
                     </block>
                   </visual-title>
               Visibility: VISIBLE
-            VisualId: c5e5be1f-820f-49a5-9694-28062f430e15
+            VisualId: 34920740-d251-4b16-91f1-65ba6fa9c7d6
         - KPIVisual:
             Actions: []
             ChartConfiguration:
@@ -975,14 +1302,14 @@ dashboards:
             ColumnHierarchies: []
             Subtitle:
               FormatText:
-                RichText: "<visual-subtitle>\n  Usage between\n      <parameter>${StartDate}</parameter>\n\
-                  \  \_and\n      <parameter>${EndDate}</parameter>\n</visual-subtitle>"
+                RichText: "<visual-subtitle>\n  Calculated for usage between\n  <parameter>${StartDate}</parameter>\n\
+                  \  \_and\n  <parameter>${EndDate}</parameter>\n</visual-subtitle>"
               Visibility: VISIBLE
             Title:
               FormatText:
-                RichText: <visual-title>Estimated Monthly Cost (Year 3)</visual-title>
+                RichText: <visual-title>Estimated Cost (Year 3)</visual-title>
               Visibility: VISIBLE
-            VisualId: 2ea5b124-a8d3-4311-9da5-98518feeeb95
+            VisualId: fff8acda-7c74-4eca-8c56-c1e60155803a
         - KPIVisual:
             Actions: []
             ChartConfiguration:
@@ -1018,14 +1345,14 @@ dashboards:
             ColumnHierarchies: []
             Subtitle:
               FormatText:
-                RichText: "<visual-subtitle>\n  Usage between\n      <parameter>${StartDate}</parameter>\n\
-                  \  \_and\n      <parameter>${EndDate}</parameter>\n</visual-subtitle>"
+                RichText: "<visual-subtitle>\n  Calculated for usage between\n  <parameter>${StartDate}</parameter>\n\
+                  \  \_and\n  <parameter>${EndDate}</parameter>\n</visual-subtitle>"
               Visibility: VISIBLE
             Title:
               FormatText:
-                RichText: <visual-title>Estimated Monthly Cost (Year 1-2)</visual-title>
+                RichText: <visual-title>Estimated Cost (Year 1-2)</visual-title>
               Visibility: VISIBLE
-            VisualId: bbb4130e-d2e8-4f0f-8c6a-a294dc9bc83a
+            VisualId: 52679c34-14d5-4061-aa17-bf1fc8a51ec2
         - PieChartVisual:
             Actions:
             - ActionOperations:
@@ -1119,7 +1446,7 @@ dashboards:
               FormatText:
                 RichText: <visual-title>vCPU/ACU Hours of Usage By Engine Version</visual-title>
               Visibility: VISIBLE
-            VisualId: 416cee8a-0600-4aaa-bb69-350727060b30
+            VisualId: 966e940f-6bda-4007-b15d-e887299acca9
         - TableVisual:
             Actions: []
             ChartConfiguration:
@@ -1294,7 +1621,7 @@ dashboards:
               FormatText:
                 RichText: <visual-title>Extended Support Estimated Cost Breakdown</visual-title>
               Visibility: VISIBLE
-            VisualId: 3594d0e0-e54e-44ce-8f1f-e50229dc458c
+            VisualId: 7a3e14c3-424d-4883-84b3-2a75b614a878
         - TableVisual:
             Actions:
             - ActionOperations:
@@ -1399,7 +1726,7 @@ dashboards:
               FormatText:
                 RichText: <visual-title>Extended Support Details</visual-title>
               Visibility: VISIBLE
-            VisualId: 34d4af34-269d-42e3-86ad-e616a362fbd6
+            VisualId: 03a6bffd-a356-40cb-a001-130dbb756153
         - KPIVisual:
             Actions: []
             ChartConfiguration:
@@ -1446,7 +1773,7 @@ dashboards:
                     </block>
                   </visual-title>
               Visibility: VISIBLE
-            VisualId: 9afc5e06-b00e-4345-8690-7424211c9bc5
+            VisualId: 02bf7f90-4e6b-4552-b672-691fd05798da
         - BarChartVisual:
             Actions:
             - ActionOperations:
@@ -1552,7 +1879,1205 @@ dashboards:
               FormatText:
                 RichText: <visual-title>vCPU/ACU Hours Breakdown - Engine by Account</visual-title>
               Visibility: VISIBLE
-            VisualId: 7c913b40-495d-4f0c-bd2b-585f39e485e8
+            VisualId: 38aac42b-71f9-47f0-bae2-76451c00b700
+      - ContentType: INTERACTIVE
+        Layouts:
+        - Configuration:
+            GridLayout:
+              CanvasSizeOptions:
+                ScreenCanvasSizeOptions:
+                  OptimizedViewPortWidth: 1600px
+                  ResizeOption: FIXED
+              Elements:
+              - ColumnIndex: 1
+                ColumnSpan: 18
+                ElementId: 97ec7b63-7dc6-42aa-82c4-8b1678345ecb
+                ElementType: VISUAL
+                RowIndex: 0
+                RowSpan: 6
+              - ColumnIndex: 19
+                ColumnSpan: 16
+                ElementId: 1c907c0b-3742-4ae9-a0d2-e171fb5d7855
+                ElementType: TEXT_BOX
+                RowIndex: 0
+                RowSpan: 2
+              - ColumnIndex: 19
+                ColumnSpan: 4
+                ElementId: 2f853899-7c87-4c3e-8116-c99ec2f1ce20
+                ElementType: VISUAL
+                RowIndex: 2
+                RowSpan: 4
+              - ColumnIndex: 23
+                ColumnSpan: 4
+                ElementId: fc3ac4a1-b895-4e78-9b39-938b7ffd415e
+                ElementType: VISUAL
+                RowIndex: 2
+                RowSpan: 4
+              - ColumnIndex: 27
+                ColumnSpan: 4
+                ElementId: 9e962230-38c7-48f1-8782-f7205b5ff259
+                ElementType: VISUAL
+                RowIndex: 2
+                RowSpan: 4
+              - ColumnIndex: 31
+                ColumnSpan: 4
+                ElementId: f69eb697-076f-424f-a40c-d9fa915dc8da
+                ElementType: VISUAL
+                RowIndex: 2
+                RowSpan: 4
+              - ColumnIndex: 11
+                ColumnSpan: 14
+                ElementId: 8fff2b3b-2490-4ee1-adbd-e10fa5199940
+                ElementType: VISUAL
+                RowIndex: 6
+                RowSpan: 4
+              - ColumnIndex: 1
+                ColumnSpan: 34
+                ElementId: 0c8e79b3-2169-4f73-87de-67ca3116dca1
+                ElementType: VISUAL
+                RowIndex: 10
+                RowSpan: 9
+              - ColumnIndex: 1
+                ColumnSpan: 12
+                ElementId: 43f608d9-e0e4-49c6-bae4-71ea6ebd5a57
+                ElementType: VISUAL
+                RowIndex: 19
+                RowSpan: 9
+              - ColumnIndex: 13
+                ColumnSpan: 11
+                ElementId: ad1f27dd-f85b-4bb3-872c-b3468ac7ce53
+                ElementType: VISUAL
+                RowIndex: 19
+                RowSpan: 9
+              - ColumnIndex: 24
+                ColumnSpan: 11
+                ElementId: 621445ba-935a-43a5-8b12-d6cad2185947
+                ElementType: VISUAL
+                RowIndex: 19
+                RowSpan: 9
+              - ColumnIndex: 1
+                ColumnSpan: 17
+                ElementId: e8a807d9-a5fb-4efe-8666-18696a37403e
+                ElementType: VISUAL
+                RowIndex: 28
+                RowSpan: 12
+              - ColumnIndex: 18
+                ColumnSpan: 17
+                ElementId: 98f98793-38b7-4f7b-8e87-2a4b7ed33b4a
+                ElementType: VISUAL
+                RowIndex: 28
+                RowSpan: 12
+              - ColumnIndex: 1
+                ColumnSpan: 34
+                ElementId: 3da23b18-432f-4b6a-ab40-7f60b436c3e5
+                ElementType: VISUAL
+                RowIndex: 40
+                RowSpan: 6
+        Name: EKS Extended Support (Cost Projection)
+        ParameterControls:
+        - DateTimePicker:
+            DisplayOptions:
+              DateTimeFormat: YYYY/MM/DD
+              TitleOptions:
+                FontConfiguration:
+                  FontSize:
+                    Relative: MEDIUM
+                Visibility: VISIBLE
+            ParameterControlId: eb954c52-81b0-4fb9-a27f-15dd9b86ea34
+            SourceParameterName: StartDate
+            Title: Start Date
+        - DateTimePicker:
+            DisplayOptions:
+              DateTimeFormat: YYYY/MM/DD
+              TitleOptions:
+                FontConfiguration:
+                  FontSize:
+                    Relative: MEDIUM
+                Visibility: VISIBLE
+            ParameterControlId: 7b4ab04a-b676-4b3f-97d2-8d0b5ef3d25f
+            SourceParameterName: EndDate
+            Title: End Date
+        - Dropdown:
+            DisplayOptions:
+              SelectAllOptions:
+                Visibility: VISIBLE
+              TitleOptions:
+                FontConfiguration:
+                  FontSize:
+                    Relative: MEDIUM
+                Visibility: VISIBLE
+            ParameterControlId: 9b976266-351f-4741-8352-33e741ab5899
+            SelectableValues:
+              LinkToDataSetColumn:
+                ColumnName: payer_account_id
+                DataSetIdentifier: rds_extended_support_view
+            SourceParameterName: Payer
+            Title: Payer Account
+            Type: MULTI_SELECT
+        - Dropdown:
+            DisplayOptions:
+              SelectAllOptions:
+                Visibility: VISIBLE
+              TitleOptions:
+                FontConfiguration:
+                  FontSize:
+                    Relative: MEDIUM
+                Visibility: VISIBLE
+            ParameterControlId: 8ef51507-bc51-4ae9-b50e-82347fc94524
+            SelectableValues:
+              LinkToDataSetColumn:
+                ColumnName: linked_account_id
+                DataSetIdentifier: rds_extended_support_view
+            SourceParameterName: LinkedAccount
+            Title: Linked Account
+            Type: MULTI_SELECT
+        SheetControlLayouts:
+        - Configuration:
+            GridLayout:
+              Elements: []
+        SheetId: 388ea71f-ce1e-4725-8900-c8b552f3bbd4
+        TextBoxes:
+        - Content: |-
+            <text-box>
+              <block align="center">
+                <inline font-size="24px">
+                  <b>Clusters reaching extended support</b>
+                </inline>
+              </block>
+            </text-box>
+          SheetTextBoxId: 1c907c0b-3742-4ae9-a0d2-e171fb5d7855
+        Visuals:
+        - BarChartVisual:
+            Actions: []
+            ChartConfiguration:
+              BarsArrangement: CLUSTERED
+              CategoryAxis:
+                ScrollbarOptions:
+                  Visibility: VISIBLE
+                TickLabelOptions:
+                  LabelOptions:
+                    FontConfiguration:
+                      FontSize:
+                        Relative: MEDIUM
+              CategoryLabelOptions:
+                AxisLabelOptions:
+                - ApplyTo:
+                    Column:
+                      ColumnName: linked_account_id
+                      DataSetIdentifier: eks_extended_support_view
+                    FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.linked_account_id.2.1713291742554
+                  CustomLabel: Account
+                SortIconVisibility: HIDDEN
+              DataLabels:
+                CategoryLabelVisibility: HIDDEN
+                LabelContent: VALUE
+                LabelFontConfiguration:
+                  FontSize:
+                    Relative: EXTRA_LARGE
+                MeasureLabelVisibility: VISIBLE
+                Overlap: DISABLE_OVERLAP
+                Visibility: HIDDEN
+              FieldWells:
+                BarChartAggregatedFieldWells:
+                  Category:
+                  - CategoricalDimensionField:
+                      Column:
+                        ColumnName: linked_account_id
+                        DataSetIdentifier: eks_extended_support_view
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.linked_account_id.2.1713291742554
+                  Colors: []
+                  Values:
+                  - NumericalMeasureField:
+                      AggregationFunction:
+                        SimpleNumericalAggregation: SUM
+                      Column:
+                        ColumnName: Estimated_Extended_Support_Monthly_Cost
+                        DataSetIdentifier: eks_extended_support_view
+                      FieldId: 47d82dba-3977-447d-b2a9-7d5ca59185d6.2.1713268600878
+                      FormatConfiguration:
+                        FormatConfiguration:
+                          CurrencyDisplayFormatConfiguration:
+                            DecimalPlacesConfiguration:
+                              DecimalPlaces: 2
+                            NegativeValueConfiguration:
+                              DisplayMode: POSITIVE
+                            NullValueFormatConfiguration:
+                              NullString: 'null'
+                            NumberScale: AUTO
+                            SeparatorConfiguration:
+                              DecimalSeparator: DOT
+                              ThousandsSeparator:
+                                Symbol: COMMA
+                                Visibility: VISIBLE
+                            Symbol: USD
+              Legend:
+                Width: 138px
+              Orientation: HORIZONTAL
+              SortConfiguration:
+                CategoryItemsLimit:
+                  OtherCategories: INCLUDE
+                CategorySort:
+                - FieldSort:
+                    Direction: DESC
+                    FieldId: 47d82dba-3977-447d-b2a9-7d5ca59185d6.2.1713268600878
+                ColorItemsLimit:
+                  OtherCategories: INCLUDE
+                SmallMultiplesLimitConfiguration:
+                  OtherCategories: INCLUDE
+              Tooltip:
+                FieldBasedTooltip:
+                  AggregationVisibility: HIDDEN
+                  TooltipFields:
+                  - FieldTooltipItem:
+                      FieldId: 47d82dba-3977-447d-b2a9-7d5ca59185d6.2.1713268600878
+                      Visibility: VISIBLE
+                  - FieldTooltipItem:
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.linked_account_id.2.1713291742554
+                      Visibility: VISIBLE
+                  TooltipTitleType: PRIMARY_VALUE
+                SelectedTooltipType: DETAILED
+                TooltipVisibility: VISIBLE
+              ValueAxis:
+                TickLabelOptions:
+                  LabelOptions:
+                    FontConfiguration:
+                      FontSize:
+                        Relative: LARGE
+              ValueLabelOptions:
+                AxisLabelOptions:
+                - ApplyTo:
+                    Column:
+                      ColumnName: Estimated_Extended_Support_Monthly_Cost
+                      DataSetIdentifier: eks_extended_support_view
+                    FieldId: 47d82dba-3977-447d-b2a9-7d5ca59185d6.2.1713268600878
+                  CustomLabel: Estimated Cost
+                SortIconVisibility: HIDDEN
+                Visibility: HIDDEN
+            ColumnHierarchies: []
+            Subtitle:
+              Visibility: VISIBLE
+            Title:
+              FormatText:
+                RichText: <visual-title>Estimated Cost by Account</visual-title>
+              Visibility: VISIBLE
+            VisualId: 621445ba-935a-43a5-8b12-d6cad2185947
+        - BarChartVisual:
+            Actions: []
+            ChartConfiguration:
+              BarsArrangement: STACKED
+              CategoryAxis:
+                ScrollbarOptions:
+                  Visibility: HIDDEN
+                TickLabelOptions:
+                  LabelOptions:
+                    FontConfiguration:
+                      FontSize:
+                        Relative: LARGE
+              CategoryLabelOptions:
+                AxisLabelOptions:
+                - ApplyTo:
+                    Column:
+                      ColumnName: billing_period
+                      DataSetIdentifier: eks_extended_support_view
+                    FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.billing_period.2.1713290075646
+                  CustomLabel: Month
+                SortIconVisibility: HIDDEN
+              DataLabels:
+                CategoryLabelVisibility: HIDDEN
+                LabelContent: VALUE
+                LabelFontConfiguration:
+                  FontSize:
+                    Relative: LARGE
+                MeasureLabelVisibility: VISIBLE
+                Overlap: DISABLE_OVERLAP
+                Visibility: VISIBLE
+              FieldWells:
+                BarChartAggregatedFieldWells:
+                  Category:
+                  - DateDimensionField:
+                      Column:
+                        ColumnName: billing_period
+                        DataSetIdentifier: eks_extended_support_view
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.billing_period.2.1713290075646
+                      FormatConfiguration:
+                        DateTimeFormat: MMM YYYY
+                        NullValueFormatConfiguration:
+                          NullString: 'null'
+                      HierarchyId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.billing_period.2.1713290075646
+                  Colors:
+                  - CategoricalDimensionField:
+                      Column:
+                        ColumnName: k8s_version
+                        DataSetIdentifier: eks_extended_support_view
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.k8s_version.2.1713290105037
+                  Values:
+                  - NumericalMeasureField:
+                      AggregationFunction:
+                        SimpleNumericalAggregation: SUM
+                      Column:
+                        ColumnName: usage_amount
+                        DataSetIdentifier: eks_extended_support_view
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.usage_amount.2.1713268734606
+                      FormatConfiguration:
+                        FormatConfiguration:
+                          NumberDisplayFormatConfiguration:
+                            NullValueFormatConfiguration:
+                              NullString: 'null'
+                            NumberScale: NONE
+                            Suffix: ' hrs'
+              Legend:
+                Title:
+                  CustomLabel: Cluster Version
+                Width: 147px
+              Orientation: VERTICAL
+              SortConfiguration:
+                CategoryItemsLimit:
+                  OtherCategories: INCLUDE
+                CategorySort:
+                - FieldSort:
+                    Direction: ASC
+                    FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.billing_period.2.1713290075646
+                ColorItemsLimit:
+                  OtherCategories: INCLUDE
+                SmallMultiplesLimitConfiguration:
+                  OtherCategories: INCLUDE
+              Tooltip:
+                FieldBasedTooltip:
+                  AggregationVisibility: HIDDEN
+                  TooltipFields:
+                  - FieldTooltipItem:
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.usage_amount.2.1713268734606
+                      Visibility: VISIBLE
+                  - FieldTooltipItem:
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.billing_period.2.1713290075646
+                      Visibility: VISIBLE
+                  - FieldTooltipItem:
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.k8s_version.2.1713290105037
+                      Visibility: VISIBLE
+                  TooltipTitleType: PRIMARY_VALUE
+                SelectedTooltipType: DETAILED
+                TooltipVisibility: VISIBLE
+              ValueAxis:
+                AxisOffset: 83px
+                TickLabelOptions:
+                  LabelOptions:
+                    FontConfiguration:
+                      FontSize:
+                        Relative: EXTRA_LARGE
+              ValueLabelOptions:
+                AxisLabelOptions:
+                - ApplyTo:
+                    Column:
+                      ColumnName: usage_amount
+                      DataSetIdentifier: eks_extended_support_view
+                    FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.usage_amount.2.1713268734606
+                  CustomLabel: Hours
+            ColumnHierarchies:
+            - DateTimeHierarchy:
+                HierarchyId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.billing_period.2.1713290075646
+            Subtitle:
+              Visibility: VISIBLE
+            Title:
+              FormatText:
+                RichText: <visual-title>Usage by Cluster Version (Past 3 months + MTD)</visual-title>
+              Visibility: VISIBLE
+            VisualId: 0c8e79b3-2169-4f73-87de-67ca3116dca1
+        - TableVisual:
+            Actions: []
+            ChartConfiguration:
+              FieldOptions:
+                Order: []
+                SelectedFieldOptions:
+                - CustomLabel: Cluster Name
+                  FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.cluster_name.7.1713269679118
+                - CustomLabel: Cluster ARN
+                  FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.resource_id.4.1713269036056
+                - CustomLabel: Cluster Version
+                  FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.k8s_version.0.1713267213461
+                  Width: 146px
+                - CustomLabel: Region
+                  FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.region_code.3.1713269020978
+                - CustomLabel: Start of Extended Support
+                  FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.start_of_extended_support.1.1713267223243
+                - CustomLabel: End of Extended Support
+                  FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.end_of_extended_support.2.1713267229070
+                - CustomLabel: Hours
+                  FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.usage_amount.5.1713269061502
+                - CustomLabel: Estimated Cost
+                  FieldId: 47d82dba-3977-447d-b2a9-7d5ca59185d6.6.1713269065720
+              FieldWells:
+                TableAggregatedFieldWells:
+                  GroupBy:
+                  - CategoricalDimensionField:
+                      Column:
+                        ColumnName: cluster_name
+                        DataSetIdentifier: eks_extended_support_view
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.cluster_name.7.1713269679118
+                  - CategoricalDimensionField:
+                      Column:
+                        ColumnName: resource_id
+                        DataSetIdentifier: eks_extended_support_view
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.resource_id.4.1713269036056
+                  - CategoricalDimensionField:
+                      Column:
+                        ColumnName: k8s_version
+                        DataSetIdentifier: eks_extended_support_view
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.k8s_version.0.1713267213461
+                  - CategoricalDimensionField:
+                      Column:
+                        ColumnName: region_code
+                        DataSetIdentifier: eks_extended_support_view
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.region_code.3.1713269020978
+                  - DateDimensionField:
+                      Column:
+                        ColumnName: start_of_extended_support
+                        DataSetIdentifier: eks_extended_support_view
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.start_of_extended_support.1.1713267223243
+                  - DateDimensionField:
+                      Column:
+                        ColumnName: end_of_extended_support
+                        DataSetIdentifier: eks_extended_support_view
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.end_of_extended_support.2.1713267229070
+                  Values:
+                  - NumericalMeasureField:
+                      AggregationFunction:
+                        SimpleNumericalAggregation: SUM
+                      Column:
+                        ColumnName: usage_amount
+                        DataSetIdentifier: eks_extended_support_view
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.usage_amount.5.1713269061502
+                      FormatConfiguration:
+                        FormatConfiguration:
+                          NumberDisplayFormatConfiguration:
+                            NullValueFormatConfiguration:
+                              NullString: 'null'
+                            Suffix: ' hrs'
+                  - NumericalMeasureField:
+                      AggregationFunction:
+                        SimpleNumericalAggregation: SUM
+                      Column:
+                        ColumnName: Estimated_Extended_Support_Monthly_Cost
+                        DataSetIdentifier: eks_extended_support_view
+                      FieldId: 47d82dba-3977-447d-b2a9-7d5ca59185d6.6.1713269065720
+              SortConfiguration: {}
+              TableOptions:
+                HeaderStyle:
+                  FontConfiguration:
+                    FontSize:
+                      Relative: LARGE
+                  Height: 75
+                  HorizontalTextAlignment: CENTER
+                  TextWrap: WRAP
+              TotalOptions:
+                Placement: END
+                TotalsVisibility: VISIBLE
+            Subtitle:
+              Visibility: VISIBLE
+            Title:
+              FormatText:
+                RichText: <visual-title>Extended Support Estimated Cost Breakdown</visual-title>
+              Visibility: VISIBLE
+            VisualId: 3da23b18-432f-4b6a-ab40-7f60b436c3e5
+        - BarChartVisual:
+            Actions: []
+            ChartConfiguration:
+              BarsArrangement: STACKED
+              CategoryAxis:
+                ScrollbarOptions:
+                  Visibility: HIDDEN
+              CategoryLabelOptions:
+                AxisLabelOptions:
+                - ApplyTo:
+                    Column:
+                      ColumnName: k8s_version
+                      DataSetIdentifier: eks_extended_support_view
+                    FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.k8s_version.2.1713268839783
+                  CustomLabel: Cluster Version
+                SortIconVisibility: HIDDEN
+              DataLabels:
+                CategoryLabelVisibility: HIDDEN
+                LabelContent: VALUE
+                LabelFontConfiguration:
+                  FontSize:
+                    Relative: LARGE
+                MeasureLabelVisibility: VISIBLE
+                Overlap: DISABLE_OVERLAP
+                Visibility: VISIBLE
+              FieldWells:
+                BarChartAggregatedFieldWells:
+                  Category:
+                  - CategoricalDimensionField:
+                      Column:
+                        ColumnName: k8s_version
+                        DataSetIdentifier: eks_extended_support_view
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.k8s_version.2.1713268839783
+                  Colors:
+                  - CategoricalDimensionField:
+                      Column:
+                        ColumnName: linked_account_id
+                        DataSetIdentifier: eks_extended_support_view
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.linked_account_id.2.1713268696217
+                  Values:
+                  - NumericalMeasureField:
+                      AggregationFunction:
+                        SimpleNumericalAggregation: SUM
+                      Column:
+                        ColumnName: usage_amount
+                        DataSetIdentifier: eks_extended_support_view
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.usage_amount.2.1713268734606
+                      FormatConfiguration:
+                        FormatConfiguration:
+                          NumberDisplayFormatConfiguration:
+                            NullValueFormatConfiguration:
+                              NullString: 'null'
+                            Suffix: ' hrs'
+              Legend:
+                Title:
+                  CustomLabel: Account
+                Width: 147px
+              Orientation: VERTICAL
+              SortConfiguration:
+                CategoryItemsLimit:
+                  OtherCategories: INCLUDE
+                CategorySort:
+                - FieldSort:
+                    Direction: DESC
+                    FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.k8s_version.2.1713268839783
+                ColorItemsLimit:
+                  OtherCategories: INCLUDE
+                ColorSort:
+                - FieldSort:
+                    Direction: DESC
+                    FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.linked_account_id.2.1713268696217
+                SmallMultiplesLimitConfiguration:
+                  OtherCategories: INCLUDE
+              Tooltip:
+                FieldBasedTooltip:
+                  AggregationVisibility: HIDDEN
+                  TooltipFields:
+                  - FieldTooltipItem:
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.linked_account_id.2.1713268696217
+                      Visibility: VISIBLE
+                  - FieldTooltipItem:
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.usage_amount.2.1713268734606
+                      Visibility: VISIBLE
+                  - FieldTooltipItem:
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.k8s_version.2.1713268839783
+                      Visibility: VISIBLE
+                  TooltipTitleType: PRIMARY_VALUE
+                SelectedTooltipType: DETAILED
+                TooltipVisibility: VISIBLE
+              ValueAxis:
+                AxisOffset: 88px
+                TickLabelOptions:
+                  LabelOptions:
+                    FontConfiguration:
+                      FontSize:
+                        Relative: EXTRA_LARGE
+              ValueLabelOptions:
+                AxisLabelOptions:
+                - ApplyTo:
+                    Column:
+                      ColumnName: usage_amount
+                      DataSetIdentifier: eks_extended_support_view
+                    FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.usage_amount.2.1713268734606
+                  CustomLabel: Hours
+            ColumnHierarchies: []
+            Subtitle:
+              Visibility: VISIBLE
+            Title:
+              FormatText:
+                RichText: <visual-title>Hours Breakdown - Account by Version</visual-title>
+              Visibility: VISIBLE
+            VisualId: 98f98793-38b7-4f7b-8e87-2a4b7ed33b4a
+        - BarChartVisual:
+            Actions: []
+            ChartConfiguration:
+              BarsArrangement: STACKED
+              CategoryAxis:
+                ScrollbarOptions:
+                  Visibility: HIDDEN
+              CategoryLabelOptions:
+                AxisLabelOptions:
+                - ApplyTo:
+                    Column:
+                      ColumnName: linked_account_id
+                      DataSetIdentifier: eks_extended_support_view
+                    FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.linked_account_id.2.1713268696217
+                  CustomLabel: Account
+                SortIconVisibility: HIDDEN
+              ColorLabelOptions:
+                AxisLabelOptions:
+                - ApplyTo:
+                    Column:
+                      ColumnName: k8s_version
+                      DataSetIdentifier: eks_extended_support_view
+                    FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.k8s_version.1.1713268446184
+                  CustomLabel: Cluster Version
+              DataLabels:
+                CategoryLabelVisibility: HIDDEN
+                LabelContent: VALUE
+                LabelFontConfiguration:
+                  FontSize:
+                    Relative: LARGE
+                MeasureLabelVisibility: VISIBLE
+                Overlap: DISABLE_OVERLAP
+                Visibility: VISIBLE
+              FieldWells:
+                BarChartAggregatedFieldWells:
+                  Category:
+                  - CategoricalDimensionField:
+                      Column:
+                        ColumnName: linked_account_id
+                        DataSetIdentifier: eks_extended_support_view
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.linked_account_id.2.1713268696217
+                  Colors:
+                  - CategoricalDimensionField:
+                      Column:
+                        ColumnName: k8s_version
+                        DataSetIdentifier: eks_extended_support_view
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.k8s_version.1.1713268446184
+                  Values:
+                  - NumericalMeasureField:
+                      AggregationFunction:
+                        SimpleNumericalAggregation: SUM
+                      Column:
+                        ColumnName: usage_amount
+                        DataSetIdentifier: eks_extended_support_view
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.usage_amount.2.1713268734606
+                      FormatConfiguration:
+                        FormatConfiguration:
+                          NumberDisplayFormatConfiguration:
+                            NullValueFormatConfiguration:
+                              NullString: 'null'
+                            Suffix: ' hrs'
+              Legend:
+                Title:
+                  CustomLabel: Cluster Version
+                Width: 100px
+              Orientation: VERTICAL
+              SortConfiguration:
+                CategoryItemsLimit:
+                  OtherCategories: INCLUDE
+                CategorySort:
+                - FieldSort:
+                    Direction: DESC
+                    FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.linked_account_id.2.1713268696217
+                ColorItemsLimit:
+                  OtherCategories: INCLUDE
+                SmallMultiplesLimitConfiguration:
+                  OtherCategories: INCLUDE
+              Tooltip:
+                FieldBasedTooltip:
+                  AggregationVisibility: HIDDEN
+                  TooltipFields:
+                  - FieldTooltipItem:
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.k8s_version.1.1713268446184
+                      Visibility: VISIBLE
+                  - FieldTooltipItem:
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.linked_account_id.2.1713268696217
+                      Visibility: VISIBLE
+                  - FieldTooltipItem:
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.usage_amount.2.1713268734606
+                      Visibility: VISIBLE
+                  TooltipTitleType: PRIMARY_VALUE
+                SelectedTooltipType: DETAILED
+                TooltipVisibility: VISIBLE
+              ValueAxis:
+                AxisOffset: 87px
+                TickLabelOptions:
+                  LabelOptions:
+                    FontConfiguration:
+                      FontSize:
+                        Relative: EXTRA_LARGE
+              ValueLabelOptions:
+                AxisLabelOptions:
+                - ApplyTo:
+                    Column:
+                      ColumnName: usage_amount
+                      DataSetIdentifier: eks_extended_support_view
+                    FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.usage_amount.2.1713268734606
+                  CustomLabel: Hours
+            ColumnHierarchies: []
+            Subtitle:
+              Visibility: VISIBLE
+            Title:
+              FormatText:
+                RichText: <visual-title>Hours Breakdown - Version by Account</visual-title>
+              Visibility: VISIBLE
+            VisualId: e8a807d9-a5fb-4efe-8666-18696a37403e
+        - BarChartVisual:
+            Actions: []
+            ChartConfiguration:
+              BarsArrangement: CLUSTERED
+              CategoryAxis:
+                ScrollbarOptions:
+                  Visibility: HIDDEN
+                TickLabelOptions:
+                  LabelOptions:
+                    FontConfiguration:
+                      FontSize:
+                        Relative: LARGE
+              CategoryLabelOptions:
+                AxisLabelOptions:
+                - ApplyTo:
+                    Column:
+                      ColumnName: k8s_version
+                      DataSetIdentifier: eks_extended_support_view
+                    FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.k8s_version.1.1713268446184
+                  CustomLabel: Cluster Version
+                SortIconVisibility: HIDDEN
+              DataLabels:
+                CategoryLabelVisibility: HIDDEN
+                LabelContent: VALUE
+                LabelFontConfiguration:
+                  FontSize:
+                    Relative: EXTRA_LARGE
+                MeasureLabelVisibility: VISIBLE
+                Overlap: DISABLE_OVERLAP
+                Visibility: HIDDEN
+              FieldWells:
+                BarChartAggregatedFieldWells:
+                  Category:
+                  - CategoricalDimensionField:
+                      Column:
+                        ColumnName: k8s_version
+                        DataSetIdentifier: eks_extended_support_view
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.k8s_version.1.1713268446184
+                  Colors: []
+                  Values:
+                  - NumericalMeasureField:
+                      AggregationFunction:
+                        SimpleNumericalAggregation: SUM
+                      Column:
+                        ColumnName: Estimated_Extended_Support_Monthly_Cost
+                        DataSetIdentifier: eks_extended_support_view
+                      FieldId: 47d82dba-3977-447d-b2a9-7d5ca59185d6.2.1713268600878
+                      FormatConfiguration:
+                        FormatConfiguration:
+                          CurrencyDisplayFormatConfiguration:
+                            DecimalPlacesConfiguration:
+                              DecimalPlaces: 2
+                            NegativeValueConfiguration:
+                              DisplayMode: POSITIVE
+                            NullValueFormatConfiguration:
+                              NullString: 'null'
+                            SeparatorConfiguration:
+                              DecimalSeparator: DOT
+                              ThousandsSeparator:
+                                Symbol: COMMA
+                                Visibility: VISIBLE
+                            Symbol: USD
+              Legend:
+                Width: 100px
+              Orientation: HORIZONTAL
+              SortConfiguration:
+                CategoryItemsLimit:
+                  OtherCategories: INCLUDE
+                CategorySort:
+                - FieldSort:
+                    Direction: DESC
+                    FieldId: 47d82dba-3977-447d-b2a9-7d5ca59185d6.2.1713268600878
+                ColorItemsLimit:
+                  OtherCategories: INCLUDE
+                SmallMultiplesLimitConfiguration:
+                  OtherCategories: INCLUDE
+              Tooltip:
+                FieldBasedTooltip:
+                  AggregationVisibility: HIDDEN
+                  TooltipFields:
+                  - FieldTooltipItem:
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.k8s_version.1.1713268446184
+                      Visibility: VISIBLE
+                  - FieldTooltipItem:
+                      FieldId: 47d82dba-3977-447d-b2a9-7d5ca59185d6.2.1713268600878
+                      Visibility: VISIBLE
+                  TooltipTitleType: PRIMARY_VALUE
+                SelectedTooltipType: DETAILED
+                TooltipVisibility: VISIBLE
+              ValueAxis:
+                TickLabelOptions:
+                  LabelOptions:
+                    FontConfiguration:
+                      FontSize:
+                        Relative: LARGE
+              ValueLabelOptions:
+                AxisLabelOptions:
+                - ApplyTo:
+                    Column:
+                      ColumnName: Estimated_Extended_Support_Monthly_Cost
+                      DataSetIdentifier: eks_extended_support_view
+                    FieldId: 47d82dba-3977-447d-b2a9-7d5ca59185d6.2.1713268600878
+                  CustomLabel: Estimated Cost
+                SortIconVisibility: HIDDEN
+                Visibility: HIDDEN
+            ColumnHierarchies: []
+            Subtitle:
+              Visibility: VISIBLE
+            Title:
+              FormatText:
+                RichText: <visual-title>Estimated Cost by Cluster Version</visual-title>
+              Visibility: VISIBLE
+            VisualId: ad1f27dd-f85b-4bb3-872c-b3468ac7ce53
+        - KPIVisual:
+            Actions: []
+            ChartConfiguration:
+              FieldWells:
+                TargetValues: []
+                TrendGroups: []
+                Values:
+                - CategoricalMeasureField:
+                    AggregationFunction: DISTINCT_COUNT
+                    Column:
+                      ColumnName: resource_id
+                      DataSetIdentifier: eks_extended_support_view
+                    FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.resource_id.0.1713267371913
+              KPIOptions:
+                Comparison:
+                  ComparisonMethod: PERCENT_DIFFERENCE
+                PrimaryValueDisplayType: ACTUAL
+                PrimaryValueFontConfiguration:
+                  FontSize:
+                    Relative: LARGE
+                SecondaryValueFontConfiguration:
+                  FontSize:
+                    Relative: EXTRA_LARGE
+                Sparkline:
+                  Type: AREA
+                  Visibility: VISIBLE
+                VisualLayoutOptions:
+                  StandardLayout:
+                    Type: VERTICAL
+              SortConfiguration: {}
+            ColumnHierarchies: []
+            Subtitle:
+              Visibility: VISIBLE
+            Title:
+              FormatText:
+                RichText: |-
+                  <visual-title>
+                    <block align="center">
+                      <inline font-size="16px">
+                        <b>In more than 12 months</b>
+                      </inline>
+                    </block>
+                  </visual-title>
+              Visibility: VISIBLE
+            VisualId: f69eb697-076f-424f-a40c-d9fa915dc8da
+        - KPIVisual:
+            Actions: []
+            ChartConfiguration:
+              FieldWells:
+                TargetValues: []
+                TrendGroups: []
+                Values:
+                - CategoricalMeasureField:
+                    AggregationFunction: DISTINCT_COUNT
+                    Column:
+                      ColumnName: resource_id
+                      DataSetIdentifier: eks_extended_support_view
+                    FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.resource_id.0.1713267371913
+              KPIOptions:
+                Comparison:
+                  ComparisonMethod: PERCENT_DIFFERENCE
+                PrimaryValueDisplayType: ACTUAL
+                PrimaryValueFontConfiguration:
+                  FontColor: '#B9E52F'
+                  FontSize:
+                    Relative: LARGE
+                SecondaryValueFontConfiguration:
+                  FontSize:
+                    Relative: EXTRA_LARGE
+                Sparkline:
+                  Type: AREA
+                  Visibility: VISIBLE
+                VisualLayoutOptions:
+                  StandardLayout:
+                    Type: VERTICAL
+              SortConfiguration: {}
+            ColumnHierarchies: []
+            Subtitle:
+              Visibility: VISIBLE
+            Title:
+              FormatText:
+                RichText: |-
+                  <visual-title>
+                    <block align="center">
+                      <inline font-size="16px">
+                        <b>In 6 to 12 months</b>
+                      </inline>
+                    </block>
+                  </visual-title>
+              Visibility: VISIBLE
+            VisualId: 9e962230-38c7-48f1-8782-f7205b5ff259
+        - KPIVisual:
+            Actions: []
+            ChartConfiguration:
+              FieldWells:
+                TargetValues: []
+                TrendGroups: []
+                Values:
+                - CategoricalMeasureField:
+                    AggregationFunction: DISTINCT_COUNT
+                    Column:
+                      ColumnName: resource_id
+                      DataSetIdentifier: eks_extended_support_view
+                    FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.resource_id.0.1713267371913
+              KPIOptions:
+                Comparison:
+                  ComparisonMethod: PERCENT_DIFFERENCE
+                PrimaryValueDisplayType: ACTUAL
+                PrimaryValueFontConfiguration:
+                  FontColor: '#F6AA54'
+                  FontSize:
+                    Relative: LARGE
+                SecondaryValueFontConfiguration:
+                  FontSize:
+                    Relative: EXTRA_LARGE
+                Sparkline:
+                  Type: AREA
+                  Visibility: VISIBLE
+                VisualLayoutOptions:
+                  StandardLayout:
+                    Type: VERTICAL
+              SortConfiguration: {}
+            ColumnHierarchies: []
+            Subtitle:
+              Visibility: VISIBLE
+            Title:
+              FormatText:
+                RichText: |-
+                  <visual-title>
+                    <block align="center">
+                      <inline font-size="16px">
+                        <b>In 3 to 6 months</b>
+                      </inline>
+                    </block>
+                  </visual-title>
+              Visibility: VISIBLE
+            VisualId: fc3ac4a1-b895-4e78-9b39-938b7ffd415e
+        - TableVisual:
+            Actions: []
+            ChartConfiguration:
+              FieldOptions:
+                Order: []
+                SelectedFieldOptions:
+                - CustomLabel: Cluster Version
+                  FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.k8s_version.0.1713267213461
+                  Width: 115px
+                - CustomLabel: Start of Extended Support
+                  FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.start_of_extended_support.1.1713267223243
+                - CustomLabel: End of Extended Support
+                  FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.end_of_extended_support.2.1713267229070
+              FieldWells:
+                TableAggregatedFieldWells:
+                  GroupBy:
+                  - CategoricalDimensionField:
+                      Column:
+                        ColumnName: k8s_version
+                        DataSetIdentifier: eks_extended_support_view
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.k8s_version.0.1713267213461
+                  - DateDimensionField:
+                      Column:
+                        ColumnName: start_of_extended_support
+                        DataSetIdentifier: eks_extended_support_view
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.start_of_extended_support.1.1713267223243
+                  - DateDimensionField:
+                      Column:
+                        ColumnName: end_of_extended_support
+                        DataSetIdentifier: eks_extended_support_view
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.end_of_extended_support.2.1713267229070
+                  Values: []
+              SortConfiguration: {}
+              TableOptions:
+                HeaderStyle:
+                  Height: 25
+                  TextWrap: WRAP
+            Subtitle:
+              Visibility: VISIBLE
+            Title:
+              FormatText:
+                RichText: <visual-title>Extended Support Details</visual-title>
+              Visibility: VISIBLE
+            VisualId: 97ec7b63-7dc6-42aa-82c4-8b1678345ecb
+        - KPIVisual:
+            Actions: []
+            ChartConfiguration:
+              FieldWells:
+                TargetValues: []
+                TrendGroups: []
+                Values:
+                - CategoricalMeasureField:
+                    AggregationFunction: DISTINCT_COUNT
+                    Column:
+                      ColumnName: resource_id
+                      DataSetIdentifier: eks_extended_support_view
+                    FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.resource_id.0.1713267371913
+              KPIOptions:
+                Comparison:
+                  ComparisonMethod: PERCENT_DIFFERENCE
+                PrimaryValueDisplayType: ACTUAL
+                PrimaryValueFontConfiguration:
+                  FontColor: '#DE3B00'
+                  FontSize:
+                    Relative: LARGE
+                SecondaryValueFontConfiguration:
+                  FontSize:
+                    Relative: EXTRA_LARGE
+                Sparkline:
+                  Type: AREA
+                  Visibility: VISIBLE
+                VisualLayoutOptions:
+                  StandardLayout:
+                    Type: VERTICAL
+              SortConfiguration: {}
+            ColumnHierarchies: []
+            Subtitle:
+              Visibility: VISIBLE
+            Title:
+              FormatText:
+                RichText: |-
+                  <visual-title>
+                    <block align="center">
+                      <inline font-size="16px">
+                        <b>In less than 3 months</b>
+                      </inline>
+                    </block>
+                  </visual-title>
+              Visibility: VISIBLE
+            VisualId: 2f853899-7c87-4c3e-8116-c99ec2f1ce20
+        - KPIVisual:
+            Actions: []
+            ChartConfiguration:
+              FieldWells:
+                TargetValues: []
+                TrendGroups: []
+                Values:
+                - NumericalMeasureField:
+                    AggregationFunction:
+                      SimpleNumericalAggregation: SUM
+                    Column:
+                      ColumnName: Estimated_Extended_Support_Monthly_Cost
+                      DataSetIdentifier: eks_extended_support_view
+                    FieldId: 47d82dba-3977-447d-b2a9-7d5ca59185d6.0.1713268212071
+              KPIOptions:
+                Comparison:
+                  ComparisonMethod: PERCENT_DIFFERENCE
+                PrimaryValueDisplayType: ACTUAL
+                PrimaryValueFontConfiguration:
+                  FontColor: '#212121'
+                  FontSize:
+                    Relative: LARGE
+                SecondaryValueFontConfiguration:
+                  FontSize:
+                    Relative: EXTRA_LARGE
+                Sparkline:
+                  Type: AREA
+                  Visibility: VISIBLE
+                VisualLayoutOptions:
+                  StandardLayout:
+                    Type: VERTICAL
+              SortConfiguration: {}
+            ColumnHierarchies: []
+            Subtitle:
+              FormatText:
+                RichText: "<visual-subtitle>\n  Calculated for usage between\n  <parameter>${StartDate}</parameter>\n\
+                  \  \_and\n  <parameter>${EndDate}</parameter>\n</visual-subtitle>"
+              Visibility: VISIBLE
+            Title:
+              FormatText:
+                RichText: <visual-title>Total Estimated Cost</visual-title>
+              Visibility: VISIBLE
+            VisualId: 8fff2b3b-2490-4ee1-adbd-e10fa5199940
+        - PieChartVisual:
+            Actions: []
+            ChartConfiguration:
+              CategoryLabelOptions:
+                AxisLabelOptions:
+                - ApplyTo:
+                    Column:
+                      ColumnName: k8s_version
+                      DataSetIdentifier: eks_extended_support_view
+                    FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.k8s_version.1.1713268446184
+                  CustomLabel: Cluster Version
+                SortIconVisibility: HIDDEN
+              DataLabels:
+                CategoryLabelVisibility: HIDDEN
+                LabelContent: VALUE
+                LabelFontConfiguration:
+                  FontSize:
+                    Relative: EXTRA_LARGE
+                MeasureLabelVisibility: VISIBLE
+                Overlap: DISABLE_OVERLAP
+                Visibility: VISIBLE
+              DonutOptions:
+                ArcOptions:
+                  ArcThickness: WHOLE
+              FieldWells:
+                PieChartAggregatedFieldWells:
+                  Category:
+                  - CategoricalDimensionField:
+                      Column:
+                        ColumnName: k8s_version
+                        DataSetIdentifier: eks_extended_support_view
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.k8s_version.1.1713268446184
+                  Values:
+                  - NumericalMeasureField:
+                      AggregationFunction:
+                        SimpleNumericalAggregation: SUM
+                      Column:
+                        ColumnName: usage_amount
+                        DataSetIdentifier: eks_extended_support_view
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.usage_amount.0.1713268442284
+                      FormatConfiguration:
+                        FormatConfiguration:
+                          NumberDisplayFormatConfiguration:
+                            NullValueFormatConfiguration:
+                              NullString: 'null'
+                            Suffix: ' hrs'
+              Legend:
+                Title:
+                  CustomLabel: Cluster Version
+                Width: 121px
+              SortConfiguration:
+                CategoryItemsLimit:
+                  OtherCategories: INCLUDE
+                CategorySort:
+                - FieldSort:
+                    Direction: DESC
+                    FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.usage_amount.0.1713268442284
+                SmallMultiplesLimitConfiguration:
+                  OtherCategories: INCLUDE
+              Tooltip:
+                FieldBasedTooltip:
+                  AggregationVisibility: HIDDEN
+                  TooltipFields:
+                  - FieldTooltipItem:
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.usage_amount.0.1713268442284
+                      Visibility: VISIBLE
+                  - FieldTooltipItem:
+                      FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.k8s_version.1.1713268446184
+                      Visibility: VISIBLE
+                  TooltipTitleType: PRIMARY_VALUE
+                SelectedTooltipType: DETAILED
+                TooltipVisibility: VISIBLE
+              ValueLabelOptions:
+                AxisLabelOptions:
+                - ApplyTo:
+                    Column:
+                      ColumnName: usage_amount
+                      DataSetIdentifier: eks_extended_support_view
+                    FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.usage_amount.0.1713268442284
+                  CustomLabel: Hours
+                SortIconVisibility: HIDDEN
+            ColumnHierarchies: []
+            Subtitle:
+              Visibility: VISIBLE
+            Title:
+              FormatText:
+                RichText: <visual-title>Hours of Usage by Cluster Version</visual-title>
+              Visibility: VISIBLE
+            VisualId: 43f608d9-e0e4-49c6-bae4-71ea6ebd5a57
       - ContentType: INTERACTIVE
         Layouts:
         - Configuration:
@@ -1575,7 +3100,7 @@ dashboards:
                 RowIndex: 7
                 RowSpan: 11
         Name: About
-        SheetId: 225d0971-d8cf-41e4-8054-892d7d7fad61
+        SheetId: 6b51ffb0-1df8-427a-be71-c3212c84db78
         TextBoxes:
         - Content: "<text-box>\n  <inline font-size=\"54.88px\">Notices</inline>\n  <inline\
             \ font-size=\"12.8px\">\n    <img src=\"https://d66mvi2kszsvt.cloudfront.net/resources/dashboard-visual-analytics/About/header.png\"\
@@ -1597,7 +3122,7 @@ dashboards:
             https://catalog.workshops.aws/awscid/en-US/dashboards/advanced/rds-extended-support-cost-projection\"\
             \ target=\"_blank\">\n        <b>\n          <u>RDS Extended Support Cost Projection</u>\n\
             \        </b>\n      </a>\n    </inline>\n  </block>\n  <br/>\n  <block align=\"\
-            center\">\n    <inline font-size=\"68.8px\">\n      <b>v1.0.0</b>\n    </inline>\n\
+            center\">\n    <inline font-size=\"68.8px\">\n      <b>v1.1.0</b>\n    </inline>\n\
             \  </block>\n  <br/>\n  <block align=\"right\"/>\n  <br/>\n  <block align=\"\
             center\"/>\n  <br/>\n  <block align=\"center\"/>\n  <br/>\n  <block align=\"\
             right\">Built by: Julio Chaves, Yuriy Prykhodko, Iakov Gan, Eric Christensen</block>\n\
@@ -1609,14 +3134,91 @@ dashboards:
             https://www.youtube.com/channel/UCl0O3ASMCwA_gw0QIKzoU3Q\" target=\"_blank\"\
             >\n        <u>CID YouTube Channel</u>\n      </a>\n    </inline>\n  </block>\n\
             \  <br/>\n  <block align=\"right\">\n    If you wish to provide feedback please\
-            \ or report an error please email:\n  <inline color=\"#61d1d6\">\n      <a href=\"mailto:cloud-intelligence-dashboards@amazon.com?subject=CUDOS%20Dashboard%20Feedback\"\
-            \ target=\"_blank\">cloud-intelligence-dashboards@amazon.com</a>\n  </inline>\n  </block>\n\
-            \  <br/>\n  <block align=\"right\">Powered by: Amazon QuickSight, Amazon Athena,\
-            \ Amazon S3</block>\n  <br/>\n  <block align=\"right\"/>\n  <br/>\n  <block\
-            \ align=\"center\"/>\n  <br/>\n  <block align=\"center\"/>\n</text-box>"
+            \ or report an error please email:\n    <inline color=\"#61d1d6\">\n      <a\
+            \ href=\"mailto:cloud-intelligence-dashboards@amazon.com?subject=CUDOS%20Dashboard%20Feedback\"\
+            \ target=\"_blank\">cloud-intelligence-dashboards@amazon.com</a>\n    </inline>\n\
+            \  </block>\n  <br/>\n  <block align=\"right\">Powered by: Amazon QuickSight,\
+            \ Amazon Athena, Amazon S3</block>\n  <br/>\n  <block align=\"right\"/>\n  <br/>\n\
+            \  <block align=\"center\"/>\n  <br/>\n  <block align=\"center\"/>\n</text-box>"
           SheetTextBoxId: 220552cd-5f25-460c-951f-98d1ccbda80d
         Visuals: []
 datasets:
+  eks_extended_support_view:
+    data:
+      DataSetId: 321e897c-7912-4cfd-bd4c-d15d0f948127
+      Name: eks_extended_support_view
+      PhysicalTableMap:
+        2ae1dbc5-c18b-4751-8473-5864f5e91d44:
+          RelationalTable:
+            DataSourceArn: ${athena_datasource_arn}
+            Catalog: AwsDataCatalog
+            Schema: ${athena_database_name}
+            Name: eks_extended_support_view
+            InputColumns:
+            - Name: billing_period
+              Type: DATETIME
+            - Name: usage_date
+              Type: DATETIME
+            - Name: payer_account_id
+              Type: STRING
+            - Name: linked_account_id
+              Type: STRING
+            - Name: region_code
+              Type: STRING
+            - Name: original_usage_type
+              Type: STRING
+            - Name: k8s_version
+              Type: STRING
+            - Name: item_description
+              Type: STRING
+            - Name: cluster_name
+              Type: STRING
+            - Name: resource_id
+              Type: STRING
+            - Name: usage_amount
+              Type: DECIMAL
+              SubType: FLOAT
+            - Name: start_of_extended_support
+              Type: DATETIME
+            - Name: is_extended_support
+              Type: STRING
+            - Name: extended_support_cost
+              Type: DECIMAL
+              SubType: FLOAT
+            - Name: end_of_extended_support
+              Type: DATETIME
+            - Name: is_out_of_extended_support
+              Type: STRING
+      LogicalTableMap:
+        2cbef0f5-bd73-4791-840e-7221b6fb58e0:
+          Alias: eks_extended_support_view
+          DataTransforms:
+          - ProjectOperation:
+              ProjectedColumns:
+              - billing_period
+              - usage_date
+              - payer_account_id
+              - linked_account_id
+              - region_code
+              - original_usage_type
+              - k8s_version
+              - item_description
+              - cluster_name
+              - resource_id
+              - usage_amount
+              - start_of_extended_support
+              - is_extended_support
+              - extended_support_cost
+              - end_of_extended_support
+              - is_out_of_extended_support
+          Source:
+            PhysicalTableId: 2ae1dbc5-c18b-4751-8473-5864f5e91d44
+      ImportMode: SPICE
+    dependsOn:
+      views:
+      - eks_extended_support_view
+    schedules:
+    - default
   rds_extended_support_view:
     data:
       DataSetId: 31961243-0137-4201-a8d1-c2a00755765e
@@ -1740,6 +3342,93 @@ datasets:
     schedules:
     - default
 views:
+  eks_extended_support_view:
+    dependsOn:
+      cur: true
+    data: |-
+      CREATE OR REPLACE VIEW ${athena_database_name}.eks_extended_support_view AS
+      WITH
+        eks_k8s_release_calendar (k8s_version, start_of_extended_support, end_of_extended_support) AS (
+         SELECT *
+         FROM
+           (
+       VALUES
+              ROW ('1.21', CAST('2023-02-17' AS timestamp), CAST('2024-07-15' AS timestamp))
+            , ROW ('1.22', CAST('2023-06-05' AS timestamp), CAST('2024-09-01' AS timestamp))
+            , ROW ('1.23', CAST('2023-10-12' AS timestamp), CAST('2024-10-11' AS timestamp))
+            , ROW ('1.24', CAST('2024-02-01' AS timestamp), CAST('2025-01-31' AS timestamp))
+            , ROW ('1.25', CAST('2024-05-02' AS timestamp), CAST('2025-05-01' AS timestamp))
+            , ROW ('1.26', CAST('2024-06-12' AS timestamp), CAST('2025-06-11' AS timestamp))
+            , ROW ('1.27', CAST('2024-07-25' AS timestamp), CAST('2025-07-24' AS timestamp))
+            , ROW ('1.28', CAST('2024-11-27' AS timestamp), CAST('2025-11-26' AS timestamp))
+            , ROW ('1.29', CAST('2025-03-24' AS timestamp), CAST('2026-03-23' AS timestamp))
+         )
+      )
+      , eks_clusters_inventory (payer_id, accountid, region, cluster_arn, cluster_name, k8s_version) AS (
+         SELECT DISTINCT
+           payer_id
+         , accountid
+         , region
+         , arn
+         , name
+         , version
+         FROM
+           ${data_collection_database_name}.inventory_eks_data
+         WHERE (CAST("concat"("year", '-', "month", '-', "day") AS date) >= ("date_trunc"('day', current_date) - INTERVAL  '15' DAY))
+      )
+      , eks_clusters_usage (billing_period, usage_date, payer_account_id, linked_account_id, region_code, cluster_name, k8s_version, item_description, usage_unit, resource_id, original_usage_type, usage_amount) AS (
+         SELECT
+           c.bill_billing_period_start_date
+         , date_trunc('day', c.line_item_usage_start_date)
+         , c.bill_payer_account_id payer_account_id
+         , c.line_item_usage_account_id linked_account_id
+         , c.product_region
+         , eksinv.cluster_name
+         , eksinv.k8s_version
+         , c.line_item_line_item_description
+         , c.pricing_unit
+         , c.line_item_resource_id
+         , c.line_item_usage_type
+         , sum(c.line_item_usage_amount)
+         FROM
+           (${athena_database_name}.${cur_table_name} c
+         INNER JOIN eks_clusters_inventory eksinv ON ((c.bill_payer_account_id = eksinv.payer_id) AND (c.line_item_usage_account_id = eksinv.accountid) AND (c.product_region = eksinv.region) AND (c.line_item_resource_id = eksinv.cluster_arn)))
+         WHERE (((c.bill_billing_period_start_date >= ("date_trunc"('month', current_timestamp) - INTERVAL  '4' MONTH)) AND (CAST(concat(c.year, '-', c.month, '-01') AS date) >= (date_trunc('month', current_date) - INTERVAL  '4' MONTH))) AND (c.product_servicecode = 'AmazonEKS') AND (c.line_item_line_item_type IN ('Usage')) AND ((c.product_product_family = 'Compute') AND (c.line_item_usage_type LIKE '%AmazonEKS-Hours:perCluster')))
+         GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11
+      )
+      SELECT
+        ekscus.billing_period
+      , ekscus.usage_date
+      , ekscus.payer_account_id
+      , ekscus.linked_account_id
+      , ekscus.region_code
+      , ekscus.original_usage_type
+      , ekscus.k8s_version
+      , ekscus.item_description
+      , ekscus.cluster_name
+      , ekscus.resource_id
+      , ekscus.usage_amount
+      , rc.start_of_extended_support
+      , (CASE WHEN ((current_timestamp >= rc.start_of_extended_support) AND (current_timestamp < rc.end_of_extended_support)) THEN 'Y' ELSE 'N' END) is_extended_support
+      , (ekscus.usage_amount * 6E-1) extended_support_cost
+      , rc.end_of_extended_support
+      , (CASE WHEN (current_timestamp >= rc.end_of_extended_support) THEN 'Y' ELSE 'N' END) is_out_of_extended_support
+      FROM
+        (eks_clusters_usage ekscus
+      INNER JOIN eks_k8s_release_calendar rc ON (ekscus.k8s_version = rc.k8s_version))
+    parameters:
+        cur_database_name:
+          default: cid_cur
+          description: "Enter the name of the CUR database"
+          global: True
+        cur_table_name:
+          default: cur
+          description: "Enter the name of the CUR table"
+          global: True
+        data_collection_database_name:
+          default: optimization_data
+          description: "Enter the name of the data collection database"
+          global: True
   rds_extended_support_view:
     dependsOn:
       cur: true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding resources for the EKS Extended Support Cost Projection dashboard, including:
- Dashboard definition changes to include a new sheet with the EKS Extended Support Dashboard definition
- Dataset definition
- Data view definition and view creation SQL statement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
