### PR TITLE
Filter scad from views

### DIFF
--- a/cid/builtin/core/data/queries/cid/summary_view.sql
+++ b/cid/builtin/core/data/queries/cid/summary_view.sql
@@ -83,5 +83,8 @@
      WHEN ("line_item_line_item_type" <> 'SavingsPlanNegation') THEN "pricing_public_on_demand_cost" ELSE 0 END) "public_cost"
  FROM
   "${cur_table_name}"
- WHERE (("bill_billing_period_start_date" >= ("date_trunc"('month', current_timestamp) - INTERVAL  '7' MONTH)) AND (CAST("concat"("year", '-', "month", '-01') AS date) >= ("date_trunc"('month', current_date) - INTERVAL  '7' MONTH)))
+ WHERE 
+    (("bill_billing_period_start_date" >= ("date_trunc"('month', current_timestamp) - INTERVAL  '7' MONTH)) 
+    AND (CAST("concat"("year", '-', "month", '-01') AS date) >= ("date_trunc"('month', current_date) - INTERVAL  '7' MONTH))
+    AND "line_item_operation" NOT IN ('EKSPod-EC2','ECSTask-EC2')) 
  GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,33,34

--- a/cid/builtin/core/data/queries/cid/summary_view_ri.sql
+++ b/cid/builtin/core/data/queries/cid/summary_view_ri.sql
@@ -73,6 +73,8 @@
      WHEN ("line_item_line_item_type" <> 'SavingsPlanNegation') THEN "pricing_public_on_demand_cost" ELSE 0 END) "public_cost"
  FROM
   "${cur_table_name}"
- WHERE (("bill_billing_period_start_date" >= ("date_trunc"('month', current_timestamp) - INTERVAL  '7' MONTH)) AND (CAST("concat"("year", '-', "month", '-01') AS date) >= ("date_trunc"('month', current_date) - INTERVAL  '7' MONTH)))
-
+ WHERE 
+    (("bill_billing_period_start_date" >= ("date_trunc"('month', current_timestamp) - INTERVAL  '7' MONTH)) 
+    AND (CAST("concat"("year", '-', "month", '-01') AS date) >= ("date_trunc"('month', current_date) - INTERVAL  '7' MONTH))
+    AND "line_item_operation" NOT IN ('EKSPod-EC2','ECSTask-EC2'))
  GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,33,34

--- a/cid/builtin/core/data/queries/cid/summary_view_sp.sql
+++ b/cid/builtin/core/data/queries/cid/summary_view_sp.sql
@@ -77,6 +77,8 @@
      WHEN ("line_item_line_item_type" <> 'SavingsPlanNegation') THEN "pricing_public_on_demand_cost" ELSE 0 END) "public_cost"
  FROM
  "${cur_table_name}"
- WHERE (("bill_billing_period_start_date" >= ("date_trunc"('month', current_timestamp) - INTERVAL  '7' MONTH)) AND (CAST("concat"("year", '-', "month", '-01') AS date) >= ("date_trunc"('month', current_date) - INTERVAL  '7' MONTH)))
-
+  WHERE 
+    (("bill_billing_period_start_date" >= ("date_trunc"('month', current_timestamp) - INTERVAL  '7' MONTH)) 
+    AND (CAST("concat"("year", '-', "month", '-01') AS date) >= ("date_trunc"('month', current_date) - INTERVAL  '7' MONTH))
+    AND "line_item_operation" NOT IN ('EKSPod-EC2','ECSTask-EC2'))
  GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,33,34

--- a/cid/builtin/core/data/queries/cid/summary_view_sp_ri.sql
+++ b/cid/builtin/core/data/queries/cid/summary_view_sp_ri.sql
@@ -73,9 +73,8 @@
       WHEN ("line_item_line_item_type" <> 'SavingsPlanNegation') THEN "pricing_public_on_demand_cost" ELSE 0 END) "public_cost"
   FROM
   "${cur_table_name}"
-  WHERE (
-    ("bill_billing_period_start_date" >= ("date_trunc"('month', current_timestamp) - INTERVAL  '7' MONTH)) 
+ WHERE 
+    (("bill_billing_period_start_date" >= ("date_trunc"('month', current_timestamp) - INTERVAL  '7' MONTH)) 
     AND (CAST("concat"("year", '-', "month", '-01') AS date) >= ("date_trunc"('month', current_date) - INTERVAL  '7' MONTH))
     AND "line_item_operation" NOT IN ('EKSPod-EC2','ECSTask-EC2'))
-
   GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34

--- a/cid/builtin/core/data/queries/cid/summary_view_sp_ri.sql
+++ b/cid/builtin/core/data/queries/cid/summary_view_sp_ri.sql
@@ -73,6 +73,9 @@
       WHEN ("line_item_line_item_type" <> 'SavingsPlanNegation') THEN "pricing_public_on_demand_cost" ELSE 0 END) "public_cost"
   FROM
   "${cur_table_name}"
-  WHERE (("bill_billing_period_start_date" >= ("date_trunc"('month', current_timestamp) - INTERVAL  '7' MONTH)) AND (CAST("concat"("year", '-', "month", '-01') AS date) >= ("date_trunc"('month', current_date) - INTERVAL  '7' MONTH)))
+  WHERE (
+    ("bill_billing_period_start_date" >= ("date_trunc"('month', current_timestamp) - INTERVAL  '7' MONTH)) 
+    AND (CAST("concat"("year", '-', "month", '-01') AS date) >= ("date_trunc"('month', current_date) - INTERVAL  '7' MONTH))
+    AND "line_item_operation" NOT IN ('EKSPod-EC2','ECSTask-EC2'))
 
   GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34

--- a/cid/builtin/core/data/queries/cudos/hourly_view.sql
+++ b/cid/builtin/core/data/queries/cudos/hourly_view.sql
@@ -21,8 +21,8 @@ CREATE OR REPLACE VIEW hourly_view AS
   , "sum"("line_item_usage_amount") "usage_quantity"
   FROM
     "${cur_table_name}"
-  WHERE (
-    ((current_date - INTERVAL  '30' DAY) <= line_item_usage_start_date) 
+  WHERE 
+    (((current_date - INTERVAL  '30' DAY) <= line_item_usage_start_date) 
     AND ((("line_item_line_item_type" = 'Usage') OR ("line_item_line_item_type" = 'SavingsPlanCoveredUsage')) OR ("line_item_line_item_type" = 'DiscountedUsage'))
     AND "line_item_operation" NOT IN ('EKSPod-EC2','ECSTask-EC2'))
   GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15

--- a/cid/builtin/core/data/queries/cudos/hourly_view.sql
+++ b/cid/builtin/core/data/queries/cudos/hourly_view.sql
@@ -21,5 +21,8 @@ CREATE OR REPLACE VIEW hourly_view AS
   , "sum"("line_item_usage_amount") "usage_quantity"
   FROM
     "${cur_table_name}"
-  WHERE (((current_date - INTERVAL  '30' DAY) <= line_item_usage_start_date) AND ((("line_item_line_item_type" = 'Usage') OR ("line_item_line_item_type" = 'SavingsPlanCoveredUsage')) OR ("line_item_line_item_type" = 'DiscountedUsage')))
+  WHERE (
+    ((current_date - INTERVAL  '30' DAY) <= line_item_usage_start_date) 
+    AND ((("line_item_line_item_type" = 'Usage') OR ("line_item_line_item_type" = 'SavingsPlanCoveredUsage')) OR ("line_item_line_item_type" = 'DiscountedUsage'))
+    AND "line_item_operation" NOT IN ('EKSPod-EC2','ECSTask-EC2'))
   GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15

--- a/cid/builtin/core/data/queries/cudos/hourly_view_ri.sql
+++ b/cid/builtin/core/data/queries/cudos/hourly_view_ri.sql
@@ -21,5 +21,8 @@ CREATE OR REPLACE VIEW hourly_view AS
   , "sum"("line_item_usage_amount") "usage_quantity"
   FROM
     "${cur_table_name}"
-  WHERE (((current_date - INTERVAL  '30' DAY) <= line_item_usage_start_date) AND ((("line_item_line_item_type" = 'Usage') OR ("line_item_line_item_type" = 'SavingsPlanCoveredUsage')) OR ("line_item_line_item_type" = 'DiscountedUsage')))
+  WHERE 
+    (((current_date - INTERVAL  '30' DAY) <= line_item_usage_start_date) 
+    AND ((("line_item_line_item_type" = 'Usage') OR ("line_item_line_item_type" = 'SavingsPlanCoveredUsage')) OR ("line_item_line_item_type" = 'DiscountedUsage'))
+    AND "line_item_operation" NOT IN ('EKSPod-EC2','ECSTask-EC2'))  
   GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15

--- a/cid/builtin/core/data/queries/cudos/hourly_view_sp.sql
+++ b/cid/builtin/core/data/queries/cudos/hourly_view_sp.sql
@@ -21,5 +21,8 @@ CREATE OR REPLACE VIEW hourly_view AS
   , "sum"("line_item_usage_amount") "usage_quantity"
   FROM
     "${cur_table_name}"
-  WHERE (((current_date - INTERVAL  '30' DAY) <= line_item_usage_start_date) AND ((("line_item_line_item_type" = 'Usage') OR ("line_item_line_item_type" = 'SavingsPlanCoveredUsage')) OR ("line_item_line_item_type" = 'DiscountedUsage')))
+  WHERE 
+    (((current_date - INTERVAL  '30' DAY) <= line_item_usage_start_date) 
+    AND ((("line_item_line_item_type" = 'Usage') OR ("line_item_line_item_type" = 'SavingsPlanCoveredUsage')) OR ("line_item_line_item_type" = 'DiscountedUsage'))
+    AND "line_item_operation" NOT IN ('EKSPod-EC2','ECSTask-EC2'))
   GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15

--- a/cid/builtin/core/data/queries/cudos/hourly_view_sp_ri.sql
+++ b/cid/builtin/core/data/queries/cudos/hourly_view_sp_ri.sql
@@ -21,5 +21,8 @@ CREATE OR REPLACE VIEW hourly_view AS
     , "sum"("line_item_usage_amount") "usage_quantity"
     FROM
       "${cur_table_name}"
-    WHERE (((current_date - INTERVAL  '30' DAY) <= line_item_usage_start_date) AND ((("line_item_line_item_type" = 'Usage') OR ("line_item_line_item_type" = 'SavingsPlanCoveredUsage')) OR ("line_item_line_item_type" = 'DiscountedUsage')))
+    WHERE 
+        (((current_date - INTERVAL  '30' DAY) <= line_item_usage_start_date) 
+        AND ((("line_item_line_item_type" = 'Usage') OR ("line_item_line_item_type" = 'SavingsPlanCoveredUsage')) OR ("line_item_line_item_type" = 'DiscountedUsage'))
+        AND "line_item_operation" NOT IN ('EKSPod-EC2','ECSTask-EC2'))    
     GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15

--- a/cid/builtin/core/data/queries/cudos/resource_view.sql
+++ b/cid/builtin/core/data/queries/cudos/resource_view.sql
@@ -35,5 +35,8 @@ CREATE OR REPLACE VIEW resource_view AS
       , "sum"("line_item_unblended_cost") unblended_cost
       FROM
         "${cur_table_name}"
-      WHERE (((current_date - INTERVAL  '30' DAY) <= line_item_usage_start_date) AND (line_item_resource_id <> ''))
+      WHERE 
+            (((current_date - INTERVAL  '30' DAY) <= line_item_usage_start_date) 
+            AND (line_item_resource_id <> '')
+            AND "line_item_operation" NOT IN ('EKSPod-EC2','ECSTask-EC2'))
       GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29

--- a/cid/builtin/core/data/queries/cudos/resource_view_ri.sql
+++ b/cid/builtin/core/data/queries/cudos/resource_view_ri.sql
@@ -35,5 +35,8 @@ CREATE OR REPLACE VIEW resource_view AS
       , "sum"("line_item_unblended_cost") unblended_cost
       FROM
         "${cur_table_name}"
-      WHERE (((current_date - INTERVAL  '30' DAY) <= line_item_usage_start_date) AND (line_item_resource_id <> ''))
+      WHERE 
+            (((current_date - INTERVAL  '30' DAY) <= line_item_usage_start_date) 
+            AND (line_item_resource_id <> '')
+            AND "line_item_operation" NOT IN ('EKSPod-EC2','ECSTask-EC2'))
       GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29

--- a/cid/builtin/core/data/queries/cudos/resource_view_sp.sql
+++ b/cid/builtin/core/data/queries/cudos/resource_view_sp.sql
@@ -35,5 +35,8 @@ CREATE OR REPLACE VIEW resource_view AS
       , "sum"("line_item_unblended_cost") unblended_cost
       FROM
         "${cur_table_name}"
-      WHERE (((current_date - INTERVAL  '30' DAY) <= line_item_usage_start_date) AND (line_item_resource_id <> ''))
+      WHERE 
+            (((current_date - INTERVAL  '30' DAY) <= line_item_usage_start_date) 
+            AND (line_item_resource_id <> '')
+            AND "line_item_operation" NOT IN ('EKSPod-EC2','ECSTask-EC2'))
       GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29

--- a/cid/builtin/core/data/queries/cudos/resource_view_sp_ri.sql
+++ b/cid/builtin/core/data/queries/cudos/resource_view_sp_ri.sql
@@ -35,8 +35,8 @@ CREATE OR REPLACE VIEW resource_view AS
       , "sum"("line_item_unblended_cost") unblended_cost
       FROM
         "${cur_table_name}"
-      WHERE (
-            ((current_date - INTERVAL  '30' DAY) <= line_item_usage_start_date) 
+      WHERE 
+            (((current_date - INTERVAL  '30' DAY) <= line_item_usage_start_date) 
             AND (line_item_resource_id <> '')
             AND "line_item_operation" NOT IN ('EKSPod-EC2','ECSTask-EC2'))
       GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29

--- a/cid/builtin/core/data/queries/cudos/resource_view_sp_ri.sql
+++ b/cid/builtin/core/data/queries/cudos/resource_view_sp_ri.sql
@@ -35,5 +35,8 @@ CREATE OR REPLACE VIEW resource_view AS
       , "sum"("line_item_unblended_cost") unblended_cost
       FROM
         "${cur_table_name}"
-      WHERE (((current_date - INTERVAL  '30' DAY) <= line_item_usage_start_date) AND (line_item_resource_id <> ''))
+      WHERE (
+            ((current_date - INTERVAL  '30' DAY) <= line_item_usage_start_date) 
+            AND (line_item_resource_id <> '')
+            AND "line_item_operation" NOT IN ('EKSPod-EC2','ECSTask-EC2'))
       GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Split Allocation Cost Data (SCAD) is not necessary for summary_view, hourly_view, and resource_view as the cost is a subset of other usage. SCAD also uses new fields to visualize cost which is only used in the new SCAD dashboard. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
