### PR TITLE
Exclude CKV2_AWS_67 to workaround checkov bug

### DIFF
--- a/terraform-modules/cur-setup-destination/main.tf
+++ b/terraform-modules/cur-setup-destination/main.tf
@@ -12,6 +12,7 @@ resource "aws_s3_bucket" "this" {
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  # checkov:skip=CKV2_AWS_67:KMS Key rotation is not in scope for this module as we do not create the key
   bucket = aws_s3_bucket.this.bucket
   rule {
     apply_server_side_encryption_by_default {

--- a/terraform-modules/cur-setup-source/main.tf
+++ b/terraform-modules/cur-setup-source/main.tf
@@ -11,6 +11,7 @@ resource "aws_s3_bucket" "this" {
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  # checkov:skip=CKV2_AWS_67:KMS Key rotation is not in scope for this module as we do not create the key
   bucket = aws_s3_bucket.this.bucket
   rule {
     apply_server_side_encryption_by_default {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Works around apparent bug in checkov https://github.com/bridgecrewio/checkov/issues/6294#

The KMS key rotation is not configured on the aws_s3_bucket_server_side_encryption_configuration resource so it does not make sense to check for it there. Key rotation is outside the scope of this module.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
