### PR TITLE
fix: remove double slash from examples in terraform module docs

### DIFF
--- a/terraform-modules/README.md
+++ b/terraform-modules/README.md
@@ -25,7 +25,7 @@ for use in Cost Intelligence Dashboards. The module creates an S3 bucket with
 the necessary permissions and configuration to replicate CUR data to the
 data collection account. If you are deploying Cost Intelligence Dashboards
 for a multi-payer environment, you can deploy one instance of this module for
-each payer account. 
+each payer account.
 
 Review [module documentation](./cur-setup-source/README.md) for details
 on module requirements, inputs, and outputs.
@@ -48,7 +48,7 @@ the GitHub / git source as below.
 
 ```hcl
 module "example" {
-  source = "github.com/aws-samples/aws-cudos-framework-deployment//terraform-modules/<module name>"
+  source = "github.com/aws-samples/aws-cudos-framework-deployment/terraform-modules/<module name>"
   ...
 }
 ```
@@ -65,7 +65,7 @@ example, the following source reference will use the Terraform module
 and Cloudformation template from version 0.2.14 of this module:
 
 ```
-source = "github.com/aws-samples/aws-cudos-framework-deployment//terraform-modules/cur-setup-source?ref=0.2.14"
+source = "github.com/aws-samples/aws-cudos-framework-deployment/terraform-modules/cur-setup-source?ref=0.2.14"
 ```
 
 For a complete list of release tags, visit https://github.com/aws-samples/aws-cudos-framework-deployment/tags.
@@ -119,7 +119,7 @@ provider "aws" {
 
 # Configure exactly one destination account
 module "cur_data_collection_account" {
-  source = "github.com/aws-samples/aws-cudos-framework-deployment//terraform-modules/cur-setup-destination
+  source = "github.com/aws-samples/aws-cudos-framework-deployment/terraform-modules/cur-setup-destination
 
   source_account_ids = ["1234567890"]
   create_cur         = false # Set to true to create an additional CUR in the aggregation account
@@ -134,7 +134,7 @@ module "cur_data_collection_account" {
 
 # Configure one or more source (payer) accounts
 module "cur_payer" {
-  source = "github.com/aws-samples/aws-cudos-framework-deployment//terraform-modules/cur-setup-source"
+  source = "github.com/aws-samples/aws-cudos-framework-deployment/terraform-modules/cur-setup-source"
 
   destination_bucket_arn = module.cur_data_collection_account.cur_bucket_arn
 
@@ -169,7 +169,7 @@ used `stack_parameters`.
 # dashboard_deployment.tf
 
 module "cid_dashboards" {
-    source = "github.com/aws-samples/aws-cudos-framework-deployment//terraform-modules/cid-dashboards"
+    source = "github.com/aws-samples/aws-cudos-framework-deployment/terraform-modules/cid-dashboards"
 
     stack_name      = "Cloud-Intelligence-Dashboards"
     template_bucket = "UPDATEME" # Update with S3 bucket name

--- a/terraform-modules/cid-dashboards/README.md
+++ b/terraform-modules/cid-dashboards/README.md
@@ -14,11 +14,11 @@ resources and a custom Lambda function to create the dashboards using `cid-cmd`.
 
 ```hcl
 module "cid_dashboards" {
-    source = "github.com/aws-samples/aws-cudos-framework-deployment//terraform-modules/cid-dashboards"
+    source = "github.com/aws-samples/aws-cudos-framework-deployment/terraform-modules/cid-dashboards"
 
     stack_name      = "Cloud-Intelligence-Dashboards"
     template_bucket = "UPDATEME"
-  
+
     stack_parameters = {
       "PrerequisitesQuickSight"            = "yes"
       "PrerequisitesQuickSightPermissions" = "yes"
@@ -38,7 +38,7 @@ to the module source. For example, the following source reference will use the T
 and Cloudformation template from version 0.2.13 of this module:
 
 ```
-source = "github.com/aws-samples/aws-cudos-framework-deployment//terraform-modules/cid-dashboards?ref=0.2.13"
+source = "github.com/aws-samples/aws-cudos-framework-deployment/terraform-modules/cid-dashboards?ref=0.2.13"
 ```
 
 For a complete list of release tags, visit https://github.com/aws-samples/aws-cudos-framework-deployment/tags.
@@ -79,8 +79,8 @@ Type: `string`
 
 ### stack\_parameters
 
-Description: CloudFormation stack parameters. For the full list of available parameters, refer to  
-https://github.com/aws-samples/aws-cudos-framework-deployment/blob/main/cfn-templates/cid-cfn.yml.  
+Description: CloudFormation stack parameters. For the full list of available parameters, refer to
+https://github.com/aws-samples/aws-cudos-framework-deployment/blob/main/cfn-templates/cid-cfn.yml.
 For most setups, you will want to set the following parameters:
   - PrerequisitesQuickSight: yes/no
   - PrerequisitesQuickSightPermissions: yes/no

--- a/terraform-modules/cur-setup-destination/README.md
+++ b/terraform-modules/cur-setup-destination/README.md
@@ -19,7 +19,7 @@ provider "aws" {
 }
 
 module "cur_destination" {
-  source = "github.com/aws-samples/aws-cudos-framework-deployment//terraform-modules/cur-setup-destination
+  source = "github.com/aws-samples/aws-cudos-framework-deployment/terraform-modules/cur-setup-destination
 
   source_account_ids = ["1234567890"]
   create_cur         = false # Set to true to create an additional CUR in the aggregation account
@@ -39,7 +39,7 @@ to the module source. For example, the following source reference will use the T
 and Cloudformation template from version 0.2.13 of this module:
 
 ```
-source = "github.com/aws-samples/aws-cudos-framework-deployment//terraform-modules/cur-setup-destination?ref=0.2.13"
+source = "github.com/aws-samples/aws-cudos-framework-deployment/terraform-modules/cur-setup-destination?ref=0.2.13"
 ```
 
 For a complete list of release tags, visit https://github.com/aws-samples/aws-cudos-framework-deployment/tags.
@@ -111,10 +111,10 @@ Default: `"cur"`
 
 ### kms\_key\_id
 
-Description: !!!WARNING!!! EXPERIMENTAL - Do not use unless you know what you are doing. The correct key policies and IAM permissions  
+Description: !!!WARNING!!! EXPERIMENTAL - Do not use unless you know what you are doing. The correct key policies and IAM permissions
 on the S3 replication role must be configured external to this module.
   - If create\_cur is true, the "billingreports.amazonaws.com" service must have access to encrypt S3 objects with the key ID provided
-  - See https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication-config-for-kms-objects.html for information  
+  - See https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication-config-for-kms-objects.html for information
     on permissions required for replicating KMS-encrypted objects
 
 Type: `string`

--- a/terraform-modules/cur-setup-source/README.md
+++ b/terraform-modules/cur-setup-source/README.md
@@ -4,7 +4,7 @@ Terraform module to set up a Cost and Usage Report in a source (payer) account
 for use in Cost Intelligence Dashboards. The module creates an S3 bucket with the necessary
 permissions and configuration to replicate CUR data to the destination/aggregation account.
 If you are deploying Cost Intelligence Cashboards for a multi-payer environment, you can
-one instance of this module for each payer account. 
+one instance of this module for each payer account.
 
 ## Example Usage
 
@@ -35,7 +35,7 @@ provider "aws" {
 
 # Configure exactly one destination account
 module "cur_destination" {
-  source = "github.com/aws-samples/aws-cudos-framework-deployment//terraform-modules/cur-setup-destination
+  source = "github.com/aws-samples/aws-cudos-framework-deployment/terraform-modules/cur-setup-destination
 
   source_account_ids = ["1234567890"]
   create_cur         = false # Set to true to create an additional CUR in the aggregation account
@@ -50,7 +50,7 @@ module "cur_destination" {
 
 # Configure one or more source (payer) accounts
 module "cur_source" {
-  source = "github.com/aws-samples/aws-cudos-framework-deployment//terraform-modules/cur-setup-source"
+  source = "github.com/aws-samples/aws-cudos-framework-deployment/terraform-modules/cur-setup-source"
 
   destination_bucket_arn = module.cur_destination.cur_bucket_arn
 
@@ -71,7 +71,7 @@ to the module source. For example, the following source reference will use the T
 and Cloudformation template from version 0.2.13 of this module:
 
 ```
-source = "github.com/aws-samples/aws-cudos-framework-deployment//terraform-modules/cur-setup-source?ref=0.2.13"
+source = "github.com/aws-samples/aws-cudos-framework-deployment/terraform-modules/cur-setup-source?ref=0.2.13"
 ```
 
 For a complete list of release tags, visit https://github.com/aws-samples/aws-cudos-framework-deployment/tags.
@@ -141,10 +141,10 @@ Default: `"cur"`
 
 ### kms\_key\_id
 
-Description: !!!WARNING!!! EXPERIMENTAL - Do not use unless you know what you are doing. The correct key policies and IAM permissions  
+Description: !!!WARNING!!! EXPERIMENTAL - Do not use unless you know what you are doing. The correct key policies and IAM permissions
 on the S3 replication role must be configured external to this module.
   - The "billingreports.amazonaws.com" service must have access to encrypt objects with the key ID provided
-  - See https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication-config-for-kms-objects.html for information  
+  - See https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication-config-for-kms-objects.html for information
     on permissions required for replicating KMS-encrypted objects
 
 Type: `string`


### PR DESCRIPTION
The Terraform module examples all have a double slash in the module URLs.

Closes #847

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
