### PR TITLE
fix: close quotes terraform module documentation examples

### DIFF
--- a/terraform-modules/README.md
+++ b/terraform-modules/README.md
@@ -25,7 +25,7 @@ for use in Cost Intelligence Dashboards. The module creates an S3 bucket with
 the necessary permissions and configuration to replicate CUR data to the
 data collection account. If you are deploying Cost Intelligence Dashboards
 for a multi-payer environment, you can deploy one instance of this module for
-each payer account. 
+each payer account.
 
 Review [module documentation](./cur-setup-source/README.md) for details
 on module requirements, inputs, and outputs.
@@ -119,7 +119,7 @@ provider "aws" {
 
 # Configure exactly one destination account
 module "cur_data_collection_account" {
-  source = "github.com/aws-samples/aws-cudos-framework-deployment//terraform-modules/cur-setup-destination
+  source = "github.com/aws-samples/aws-cudos-framework-deployment//terraform-modules/cur-setup-destination"
 
   source_account_ids = ["1234567890"]
   create_cur         = false # Set to true to create an additional CUR in the aggregation account

--- a/terraform-modules/cur-setup-destination/README.md
+++ b/terraform-modules/cur-setup-destination/README.md
@@ -19,7 +19,7 @@ provider "aws" {
 }
 
 module "cur_destination" {
-  source = "github.com/aws-samples/aws-cudos-framework-deployment//terraform-modules/cur-setup-destination
+  source = "github.com/aws-samples/aws-cudos-framework-deployment//terraform-modules/cur-setup-destination"
 
   source_account_ids = ["1234567890"]
   create_cur         = false # Set to true to create an additional CUR in the aggregation account
@@ -111,10 +111,10 @@ Default: `"cur"`
 
 ### kms\_key\_id
 
-Description: !!!WARNING!!! EXPERIMENTAL - Do not use unless you know what you are doing. The correct key policies and IAM permissions  
+Description: !!!WARNING!!! EXPERIMENTAL - Do not use unless you know what you are doing. The correct key policies and IAM permissions
 on the S3 replication role must be configured external to this module.
   - If create\_cur is true, the "billingreports.amazonaws.com" service must have access to encrypt S3 objects with the key ID provided
-  - See https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication-config-for-kms-objects.html for information  
+  - See https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication-config-for-kms-objects.html for information
     on permissions required for replicating KMS-encrypted objects
 
 Type: `string`

--- a/terraform-modules/cur-setup-source/README.md
+++ b/terraform-modules/cur-setup-source/README.md
@@ -4,7 +4,7 @@ Terraform module to set up a Cost and Usage Report in a source (payer) account
 for use in Cost Intelligence Dashboards. The module creates an S3 bucket with the necessary
 permissions and configuration to replicate CUR data to the destination/aggregation account.
 If you are deploying Cost Intelligence Cashboards for a multi-payer environment, you can
-one instance of this module for each payer account. 
+one instance of this module for each payer account.
 
 ## Example Usage
 
@@ -35,7 +35,7 @@ provider "aws" {
 
 # Configure exactly one destination account
 module "cur_destination" {
-  source = "github.com/aws-samples/aws-cudos-framework-deployment//terraform-modules/cur-setup-destination
+  source = "github.com/aws-samples/aws-cudos-framework-deployment//terraform-modules/cur-setup-destination"
 
   source_account_ids = ["1234567890"]
   create_cur         = false # Set to true to create an additional CUR in the aggregation account
@@ -141,10 +141,10 @@ Default: `"cur"`
 
 ### kms\_key\_id
 
-Description: !!!WARNING!!! EXPERIMENTAL - Do not use unless you know what you are doing. The correct key policies and IAM permissions  
+Description: !!!WARNING!!! EXPERIMENTAL - Do not use unless you know what you are doing. The correct key policies and IAM permissions
 on the S3 replication role must be configured external to this module.
   - The "billingreports.amazonaws.com" service must have access to encrypt objects with the key ID provided
-  - See https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication-config-for-kms-objects.html for information  
+  - See https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication-config-for-kms-objects.html for information
     on permissions required for replicating KMS-encrypted objects
 
 Type: `string`


### PR DESCRIPTION
The TF Module has unclosed quotes in the HCL snippets.