### PR TITLE
fix: update broken link in terraform docs

### DIFF
--- a/terraform-modules/README.md
+++ b/terraform-modules/README.md
@@ -151,7 +151,7 @@ module "cur_payer" {
 
 After enabling CUR with Terraform as describe above, a few steps are necessary
 to prepare for dashboard deployment:
-  1. Complete prerequisites in [Before You Start](../../README.md#before-you-start) including Quicksight setup
+  1. Complete prerequisites in [Before You Start](../README.md#before-you-start) including Quicksight setup
   2. Create an S3 bucket to upload the CloudFormation template
 
 ### Step 3: Dashboard Setup


### PR DESCRIPTION
The link in the base directory for terraform module docs is not
correct.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
