### PR TITLE
Update SQL statement to encapsulate db name and view in quotes

### DIFF
--- a/dashboards/health-events/health-events.yaml
+++ b/dashboards/health-events/health-events.yaml
@@ -6125,7 +6125,7 @@ crawlers: {}
 views:
   health_events_view:
     data: |-
-      CREATE OR REPLACE VIEW ${athena_database_name}.health_events_view AS
+      CREATE OR REPLACE VIEW "${athena_database_name}"."health_events_view" AS
       WITH
         "core" AS (
          SELECT


### PR DESCRIPTION
Resolves issue #855 

Modify query that creates the health_events_view to encapsulate the DB name and view name in quotes. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
