### PR TITLE
Fix wrong Terraform attribute for AWS Region

### DIFF
--- a/terraform-modules/cur-setup-destination/main.tf
+++ b/terraform-modules/cur-setup-destination/main.tf
@@ -156,7 +156,7 @@ data "aws_iam_policy_document" "bucket_policy" {
       ]
       condition {
         test     = "StringEquals"
-        values   = ["arn:${data.aws_partition.this.partition}:cur:${data.aws_region.this.region}:${data.aws_caller_identity.this.account_id}:definition/*"]
+        values   = ["arn:${data.aws_partition.this.partition}:cur:${data.aws_region.this.name}:${data.aws_caller_identity.this.account_id}:definition/*"]
         variable = "aws:SourceArn"
       }
       condition {
@@ -183,7 +183,7 @@ data "aws_iam_policy_document" "bucket_policy" {
       ]
       condition {
         test     = "StringEquals"
-        values   = ["arn:${data.aws_partition.this.partition}:cur:${data.aws_region.this.region}:${data.aws_caller_identity.this.account_id}:definition/*"]
+        values   = ["arn:${data.aws_partition.this.partition}:cur:${data.aws_region.this.name}:${data.aws_caller_identity.this.account_id}:definition/*"]
         variable = "aws:SourceArn"
       }
       condition {

--- a/terraform-modules/cur-setup-source/main.tf
+++ b/terraform-modules/cur-setup-source/main.tf
@@ -124,7 +124,7 @@ data "aws_iam_policy_document" "bucket_policy" {
     ]
     condition {
       test     = "StringEquals"
-      values   = ["arn:${data.aws_partition.this.partition}:cur:${data.aws_region.this.region}:${data.aws_caller_identity.this.account_id}:definition/*"]
+      values   = ["arn:${data.aws_partition.this.partition}:cur:${data.aws_region.this.name}:${data.aws_caller_identity.this.account_id}:definition/*"]
       variable = "aws:SourceArn"
     }
     condition {
@@ -148,7 +148,7 @@ data "aws_iam_policy_document" "bucket_policy" {
     ]
     condition {
       test     = "StringEquals"
-      values   = ["arn:${data.aws_partition.this.partition}:cur:${data.aws_region.this.region}:${data.aws_caller_identity.this.account_id}:definition/*"]
+      values   = ["arn:${data.aws_partition.this.partition}:cur:${data.aws_region.this.name}:${data.aws_caller_identity.this.account_id}:definition/*"]
       variable = "aws:SourceArn"
     }
     condition {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
As per the AWS Provider documentation at https://registry.terraform.io/providers/hashicorp/aws/5.55.0/docs/data-sources/region#attribute-reference, there is no attribute called `region`. 
Using the module as is results with errors like this:

```
 Error: Unsupported attribute
│ 
│   on .terraform/modules/cur_source/terraform-modules/cur-setup-source/main.tf line 127, in data "aws_iam_policy_document" "bucket_policy":
│  127:       values   = ["arn:${data.aws_partition.this.partition}:cur:${data.aws_region.this.region}:${data.aws_caller_identity.this.account_id}:definition/*"]
│ 
│ This object has no argument, nested block, or exported attribute named
│ "region".

```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
