### PR TITLE
Attempt fixing S3 resource policy introduced in #825

### DIFF
--- a/terraform-modules/cur-setup-destination/main.tf
+++ b/terraform-modules/cur-setup-destination/main.tf
@@ -155,7 +155,7 @@ data "aws_iam_policy_document" "bucket_policy" {
         "${aws_s3_bucket.this.arn}/*",
       ]
       condition {
-        test     = "StringEquals"
+        test     = "StringLike"
         values   = ["arn:${data.aws_partition.this.partition}:cur:${data.aws_region.this.name}:${data.aws_caller_identity.this.account_id}:definition/*"]
         variable = "aws:SourceArn"
       }

--- a/terraform-modules/cur-setup-source/main.tf
+++ b/terraform-modules/cur-setup-source/main.tf
@@ -147,7 +147,7 @@ data "aws_iam_policy_document" "bucket_policy" {
       "${aws_s3_bucket.this.arn}/*",
     ]
     condition {
-      test     = "StringEquals"
+      test     = "StringLike"
       values   = ["arn:${data.aws_partition.this.partition}:cur:${data.aws_region.this.name}:${data.aws_caller_identity.this.account_id}:definition/*"]
       variable = "aws:SourceArn"
     }


### PR DESCRIPTION
PR #825 introduced new iam conditions, one of them uses wildcard without Like operator

To be honest I don't even know if the SourceArn is required/valid, but we're currently troubleshooting missing cur reports and making the policy valid is first step.

Right now cur reports issues with S3 bucket permissions

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
