### PR TITLE
Adjusting CidCmdQSRole resource name in permissions

### DIFF
--- a/cid/common.py
+++ b/cid/common.py
@@ -1326,7 +1326,7 @@ class Cid():
             if "<ADD NEW ROLE>" in choice or choice == cid_role_name: # Create or update role
                 # TODO: get buckets from dashboard parameters
                 buckets = [
-                    f'cid-{self.base.account_id}-share',
+                    f'cid-{self.base.account_id}-shared',
                     f'cid-{self.base.account_id}-data-exports',
                     f'cid-data-{self.base.account_id}',
                     f'costoptimizationdata{self.base.account_id}',


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
- Adding letter 'd' at the end of the bucket name defined in the permissions for the CidCmdQuickSightDataSourceRole role.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
