### PR TITLE
Changed to StringLike for conditions with wildcard for Get operations

### DIFF
--- a/terraform-modules/cur-setup-destination/main.tf
+++ b/terraform-modules/cur-setup-destination/main.tf
@@ -184,7 +184,7 @@ data "aws_iam_policy_document" "bucket_policy" {
         "${aws_s3_bucket.this.arn}/*",
       ]
       condition {
-        test     = "StringEquals"
+        test     = "StringLike"
         values   = ["arn:${data.aws_partition.this.partition}:cur:${data.aws_region.this.name}:${data.aws_caller_identity.this.account_id}:definition/*"]
         variable = "aws:SourceArn"
       }

--- a/terraform-modules/cur-setup-source/main.tf
+++ b/terraform-modules/cur-setup-source/main.tf
@@ -125,7 +125,7 @@ data "aws_iam_policy_document" "bucket_policy" {
       "${aws_s3_bucket.this.arn}/*",
     ]
     condition {
-      test     = "StringEquals"
+      test     = "StringLike"
       values   = ["arn:${data.aws_partition.this.partition}:cur:*:${data.aws_caller_identity.this.account_id}:definition/*"]
       variable = "aws:SourceArn"
     }


### PR DESCRIPTION
PR https://github.com/aws-samples/aws-cudos-framework-deployment/pull/825 introduced new iam conditions, one of them uses wildcard without Like operator.

This PR also updates to StringLike for conditions with wildcards for the Get operations ACL as well. This was missing for PR https://github.com/aws-samples/aws-cudos-framework-deployment/pull/879

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
