### PR TITLE
Update EKS view release and extended support calendar

### DIFF
--- a/changes/CHANGELOG-extended-support-cost-projection.md
+++ b/changes/CHANGELOG-extended-support-cost-projection.md
@@ -1,5 +1,19 @@
 # What's new in Extended Support Cost Projection
 
+## Extended Support Cost Projection - v2.0.0
+
+**Important:** Update to this version requires a forced and recursive update. If you have modified the Extended Support Cost Projection dashboard view queries, they will be overridden when the dashboard is updated. Consider backing-up the existing view queries if they contain custom changes you want to keep so you can re-apply them after the update takes place.
+
+To update run these commands in your CloudShell (recommended) or other terminal:
+
+```
+python3 -m ensurepip --upgrade
+pip3 install --upgrade cid-cmd
+cid-cmd update --dashboard-id extended-support-cost-projection --force --recursive
+```
+
+- Added Kubernetes version 1.30 to the calendar data in the EKS view definition.
+
 ## Extended Support Cost Projection - v1.2.0
 
 **Important:** Update to this version requires a forced and recursive update. If you have modified the Extended Support Cost Projection dashboard view queries, they will be overridden when the dashboard is updated. Consider backing-up the existing view queries if they contain custom changes you want to keep so you can re-apply them after the update takes place.

--- a/dashboards/extended-support-cost-projection/extended-support-cost-projection.yaml
+++ b/dashboards/extended-support-cost-projection/extended-support-cost-projection.yaml
@@ -3277,7 +3277,7 @@ dashboards:
             center\">\n    <inline color=\"#61d1d6\">\n      <a href=\"https://catalog.workshops.aws/awscid/en-US/dashboards/advanced/rds-extended-support-cost-projection\"\
             \ target=\"_blank\">\n        <b>\n          <u>RDS Extended Support Cost Projection</u>\n\
             \        </b>\n      </a>\n    </inline>\n  </block>\n  <br/>\n  <block align=\"\
-            center\">\n    <b>v1.2.0</b>\n  </block>\n  <br/>\n  <block align=\"right\"\
+            center\">\n    <b>v2.0.0</b>\n  </block>\n  <br/>\n  <block align=\"right\"\
             />\n  <br/>\n  <block align=\"center\"/>\n  <br/>\n  <block align=\"center\"\
             />\n  <br/>\n  <block align=\"right\">Built by: Julio Chaves, Yuriy Prykhodko,\
             \ Iakov Gan, Eric Christensen</block>\n  <br/>\n  <block align=\"right\">\n\

--- a/dashboards/extended-support-cost-projection/extended-support-cost-projection.yaml
+++ b/dashboards/extended-support-cost-projection/extended-support-cost-projection.yaml
@@ -3523,6 +3523,7 @@ views:
             , ROW ('1.27', CAST('2024-07-25' AS timestamp), CAST('2025-07-24' AS timestamp))
             , ROW ('1.28', CAST('2024-11-27' AS timestamp), CAST('2025-11-26' AS timestamp))
             , ROW ('1.29', CAST('2025-03-24' AS timestamp), CAST('2026-03-23' AS timestamp))
+            , ROW ('1.30', CAST('2025-07-24' AS timestamp), CAST('2026-07-23' AS timestamp))
          )
       )
       , preprocessed_eks_clusters_inventory (payer_id, accountid, region, cluster_arn, cluster_name, k8s_version, collection_date, max_collection_date) AS (


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding k8s version 1.30 and dates for start and end of extended support to the EKS view calendar query.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
