### PR TITLE
Fixes to extended support price calculations and dashboard price box titles

### DIFF
--- a/changes/CHANGELOG-extended-support-cost-projection.md
+++ b/changes/CHANGELOG-extended-support-cost-projection.md
@@ -1,5 +1,17 @@
 # What's new in Extended Support Cost Projection
 
+## Extended Support Cost Projection - v3.1.0
+
+**Important:** This version requires the data collection version 3.2.0+. Update to this version requires a forced and recursive update. If you have modified the Extended Support Cost Projection dashboard view queries, they will be overridden when the dashboard is updated. Consider backing-up the existing view queries if they contain custom changes you want to keep so you can re-apply them after the update takes place.
+
+To update run these commands in your CloudShell (recommended) or other terminal:
+
+```
+python3 -m ensurepip --upgrade
+pip3 install --upgrade cid-cmd
+cid-cmd update --dashboard-id extended-support-cost-projection --force --recursive
+```
+
 ## Extended Support Cost Projection - v3.0.0
 
 **Important:** This version requires the data collection version 3.2.0+. Update to this version requires a forced and recursive update. If you have modified the Extended Support Cost Projection dashboard view queries, they will be overridden when the dashboard is updated. Consider backing-up the existing view queries if they contain custom changes you want to keep so you can re-apply them after the update takes place.

--- a/dashboards/extended-support-cost-projection/extended-support-cost-projection.yaml
+++ b/dashboards/extended-support-cost-projection/extended-support-cost-projection.yaml
@@ -1303,7 +1303,7 @@ dashboards:
               Visibility: VISIBLE
             Title:
               FormatText:
-                RichText: <visual-title>Estimated Cost (Year 3)</visual-title>
+                RichText: <visual-title>Estimated Cost For Selected Period During Year 3</visual-title>
               Visibility: VISIBLE
             VisualId: ce2771c2-3aeb-4684-ac48-31ce3ac2d388
         - KPIVisual:
@@ -1346,7 +1346,7 @@ dashboards:
               Visibility: VISIBLE
             Title:
               FormatText:
-                RichText: <visual-title>Estimated Cost (Year 1-2)</visual-title>
+                RichText: <visual-title>Estimated Cost For Selected Period During Year 1-2</visual-title>
               Visibility: VISIBLE
             VisualId: 9aa60c09-e318-4847-9350-294678407c9a
         - PieChartVisual:
@@ -3809,7 +3809,7 @@ views:
          , c.product_deployment_option
          , c.line_item_usage_type
          , sum(c.line_item_usage_amount)
-         , sum((CASE WHEN (c.pricing_unit = 'ACU-Hr') THEN c.line_item_usage_amount ELSE (CAST(c.product_vcpu AS int) * c.line_item_usage_amount) END))
+         , sum((CASE WHEN (c.pricing_unit = 'ACU-Hr') THEN c.line_item_usage_amount WHEN (c.line_item_usage_type LIKE '%Multi-AZUsage%') THEN (CAST(c.product_vcpu AS int) * c.line_item_usage_amount * 2) ELSE (CAST(c.product_vcpu AS int) * c.line_item_usage_amount) END))
          FROM
            ((${cur_database_name}.${cur_table_name} c
          INNER JOIN all_sanitised_rds_resources rdsu ON ((c.bill_payer_account_id = rdsu.payer_id) AND (c.line_item_usage_account_id = rdsu.accountid) AND (c.product_region = rdsu.region) AND (split_part(c.line_item_resource_id, ':', 7) = rdsu.dbresourceidentifier)))
@@ -3853,7 +3853,10 @@ views:
         ((rds_resources rdsr
       INNER JOIN regions_pricing rp ON (rdsr.region_code = rp.region_code))
       INNER JOIN engine_release_calendar erc ON (rdsr.engineversion = erc.engineversion))
-      WHERE (rdsr.rds_type = rp.rds_type)
+      WHERE (
+        (rp.rds_type = 'AmazonRDS' and rdsr.deployment_option in ('SINGLE-AZ', 'MULTI-AZ', 'MULTI-AZ-CLUSTER')) OR
+        (rp.rds_type = 'Aurora' and rdsr.deployment_option in ('SERVERLESS', 'SERVERLESSV2'))
+      )
     parameters:
         cur_database_name:
           default: cid_cur


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix: adjusting calculation for extended support price to double the VCPU count for MULTI-AZ databases to cater for the standby database in the multi-az setup. Adjusted titles for price estimation boxes. Adjusted price resolution to ensure provisioned instances take prices from the RDS price table.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
