### PR TITLE
fix(tf): cur bucket policy add us-east-1

### DIFF
--- a/terraform-modules/cur-setup-destination/main.tf
+++ b/terraform-modules/cur-setup-destination/main.tf
@@ -158,7 +158,7 @@ data "aws_iam_policy_document" "bucket_policy" {
       ]
       condition {
         test     = "StringLike"
-        values   = ["arn:${data.aws_partition.this.partition}:cur:${data.aws_region.this.name}:${data.aws_caller_identity.this.account_id}:definition/*"]
+        values   = ["arn:${data.aws_partition.this.partition}:cur:us-east-1:${data.aws_caller_identity.this.account_id}:definition/*"]
         variable = "aws:SourceArn"
       }
       condition {
@@ -185,7 +185,7 @@ data "aws_iam_policy_document" "bucket_policy" {
       ]
       condition {
         test     = "StringLike"
-        values   = ["arn:${data.aws_partition.this.partition}:cur:${data.aws_region.this.name}:${data.aws_caller_identity.this.account_id}:definition/*"]
+        values   = ["arn:${data.aws_partition.this.partition}:cur:us-east-1:${data.aws_caller_identity.this.account_id}:definition/*"]
         variable = "aws:SourceArn"
       }
       condition {

--- a/terraform-modules/cur-setup-source/main.tf
+++ b/terraform-modules/cur-setup-source/main.tf
@@ -126,7 +126,7 @@ data "aws_iam_policy_document" "bucket_policy" {
     ]
     condition {
       test     = "StringLike"
-      values   = ["arn:${data.aws_partition.this.partition}:cur:*:${data.aws_caller_identity.this.account_id}:definition/*"]
+      values   = ["arn:${data.aws_partition.this.partition}:cur:us-east-1:${data.aws_caller_identity.this.account_id}:definition/*"]
       variable = "aws:SourceArn"
     }
     condition {
@@ -150,7 +150,7 @@ data "aws_iam_policy_document" "bucket_policy" {
     ]
     condition {
       test     = "StringLike"
-      values   = ["arn:${data.aws_partition.this.partition}:cur:*:${data.aws_caller_identity.this.account_id}:definition/*"]
+      values   = ["arn:${data.aws_partition.this.partition}:cur:us-east-1:${data.aws_caller_identity.this.account_id}:definition/*"]
       variable = "aws:SourceArn"
     }
     condition {


### PR DESCRIPTION
*Issue #989, if available:*

*Description of changes:*
Change the region to be us-east-1 for contions in cur bucket policy like the documentation [here](https://docs.aws.amazon.com/cur/latest/userguide/cur-s3.html) because cur definition and billing are just in us-east-1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
