### PR TITLE
Adds logic to return domain for GovCloud partition

### DIFF
--- a/cid/base.py
+++ b/cid/base.py
@@ -23,7 +23,9 @@ class CidBase():
 
     @property
     def domain(self) -> str:
-        if self.region.startswith('cn-'):
+        if self.partition == 'aws-us-gov':
+            return 'amazonaws-us-gov.com'
+        if self.partition == 'aws-cn':
             return 'amazonaws.cn'
         return 'aws.amazon.com'
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updates the logic for `domain` property, so that it returns correct domain for GovCloud partition.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
