### PR TITLE
Adding user agent to get request calls

### DIFF
--- a/cid/common.py
+++ b/cid/common.py
@@ -300,7 +300,7 @@ class Cid():
             logger.debug(f"Issue logging action {action}  for dashboard {dashboard_id} , due to a urllib3 exception {str(e)} . This issue will be ignored")
 
     def get_page(self, source):
-        resp = requests.get(source, timeout=10)
+        resp = requests.get(source, timeout=10, headers={'User-Agent': 'cid'})
         resp.raise_for_status()
         return resp
 


### PR DESCRIPTION
*Issue #, if available:*
cid-cmd deploy fails to get all available dashboards due to failing to get the catalog:

WARNING - Failed to load a catalog url: 403 Client Error: Forbidden for url: https://raw.githubusercontent.com/aws-samples/aws-cudos-framework-deployment/main/dashboards/catalog.yaml


*Description of changes:*

added user agent 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
