### PR TITLE
use aws_iam_role_policy to fix deprecation warning

### DIFF
--- a/terraform-modules/cur-setup-source/main.tf
+++ b/terraform-modules/cur-setup-source/main.tf
@@ -219,10 +219,12 @@ resource "aws_iam_role" "replication" {
   name_prefix        = "${var.resource_prefix}-replication"
   path               = "/${var.resource_prefix}/"
   assume_role_policy = data.aws_iam_policy_document.s3_assume_role.json
-  inline_policy {
-    name   = "S3Replication"
-    policy = data.aws_iam_policy_document.replication.json
-  }
+}
+
+resource "aws_iam_role_policy" "replication" {
+  name   = "${var.resource_prefix}-replication-policy"
+  role   = aws_iam_role.replication.id
+  policy = data.aws_iam_policy_document.replication.json
 }
 
 resource "aws_s3_bucket_replication_configuration" "replication" {


### PR DESCRIPTION
*Issue # [1016](https://github.com/aws-samples/aws-cudos-framework-deployment/issues/1016) 

*Description of changes:*

Updates the cur-setup-source module to use aws_iam_role_policy and fix a deprecation warning

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
