### PR TITLE
Enables deletion of Athena Workgroup via CFN natively, by setting RecursiveDeleteOption to true

### DIFF
--- a/cfn-templates/cid-cfn.yml
+++ b/cfn-templates/cid-cfn.yml
@@ -531,11 +531,14 @@ Resources:
     Properties:
       Name: !Sub 'CID${Suffix}'
       Description: !Sub 'Used for CloudIntelligenceDashboards${Suffix}'
+      State: ENABLED
+      RecursiveDeleteOption: true
       WorkGroupConfiguration:
         EnforceWorkGroupConfiguration: true
         ResultConfiguration:
           EncryptionConfiguration:
             EncryptionOption: SSE_S3
+          ExpectedBucketOwner: !Ref AWS::AccountId
           OutputLocation: !If [ NeedAthenaQueryResultsBucket, !Sub 's3://${MyAthenaQueryResultsBucket}/', !Sub 's3://${AthenaQueryResultsBucket}/' ]
 
   #Legacy version. Replaced by CustomResourceFunctionInit but we cannot remove it completely as it was removing workgroup on deletion of the custom resource.
@@ -582,7 +585,7 @@ Resources:
     Properties:
       FunctionName: !Sub "CidCustomResourceFunctionInit-DoNotRun${Suffix}"
       Role: !GetAtt 'InitLambdaExecutionRole.Arn'
-      Description: "Do what CFN cannot: start crawler, delete bucket with objects and delete an non empty workgroup"
+      Description: "Do what CFN cannot: start crawler and delete bucket with objects"
       Runtime: python3.11
       Architectures: [ x86_64 ] #Compatible with arm64 but it is not supported in all regions
       MemorySize: 128
@@ -602,7 +605,6 @@ Resources:
           from cid.utils import set_parameters
 
           BUCKET = os.environ['BUCKET']
-          WORKGROUP = os.environ['WORKGROUP']
           CRAWLER = os.environ['CRAWLER']
           QUICKSIGHT_USER = os.environ['QUICKSIGHT_USER']
           QUICKSIGHT_ROLE = os.environ.get('QUICKSIGHT_ROLE')
@@ -677,7 +679,6 @@ Resources:
 
           def on_delete():
               # Delete bucket (CF cannot delete if they are non-empty)
-              # and delete WorkGroup (CF cannot do that)
               s3 = boto3.resource('s3')
               log = []
 
@@ -698,24 +699,6 @@ Resources:
                           log.append(f'ERROR: {BUCKET} - {errcode}')
                   except Exception as exc:
                       log.append(f'ERROR: {BUCKET} Error: {exc}')
-
-              if WORKGROUP:
-                  try:
-                      response = boto3.client('athena').delete_work_group(
-                          WorkGroup=WORKGROUP,
-                          RecursiveDeleteOption=True
-                      )
-                      print(f'DEBUG: WorkGroup {WORKGROUP} deleted. {response}')
-                      log.append(f'INFO: WorkGroup {WORKGROUP} deleted.')
-                  except botocore.exceptions.ClientError as exc:
-                      status = exc.response["ResponseMetadata"]["HTTPStatusCode"]
-                      errcode = exc.response["Error"]["Code"]
-                      if status == 404:
-                          log.append(f'INFO:  WorkGroup {WORKGROUP} - {errcode}')
-                      else:
-                          log.append(f'ERROR: WorkGroup {WORKGROUP} - {errcode}')
-                  except Exception as exc:
-                      log.append(f'ERROR: WorkGroup {WORKGROUP} Error: {exc}')
 
               if QUICKSIGHT_ROLE:
                   try:
@@ -739,7 +722,6 @@ Resources:
       Environment:
         Variables:
           BUCKET: !If [NeedAthenaQueryResultsBucket, !Ref MyAthenaQueryResultsBucket, '']
-          WORKGROUP: !If [NeedAthenaWorkgroup, !Ref MyAthenaWorkGroup, '']
           CRAWLER: !If [NeedCURTable, !Ref MyGlueCURCrawler, '']
           QUICKSIGHT_USER: !Ref QuickSightUser
           QUICKSIGHT_ROLE: !If [ NeedQuickSightDataSourceRole, !Ref QuickSightDataSourceRole, !Ref 'AWS::NoValue' ]
@@ -789,20 +771,6 @@ Resources:
                   Resource: !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${QuickSightDataSourceRole}"
                 - !Ref 'AWS::NoValue'
       PermissionsBoundary: !If [NeedPermissionsBoundary, !Ref PermissionsBoundary, !Ref 'AWS::NoValue']
-
-  InitLambdaExecutionRoleWorkGroupPolicy:
-    Type: AWS::IAM::Policy
-    Condition: NeedAthenaWorkgroup
-    Properties:
-      PolicyName: AthenaWorkGroupDeletion
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Action: athena:DeleteWorkGroup
-            Resource: !Sub 'arn:${AWS::Partition}:athena:${AWS::Region}:${AWS::AccountId}:workgroup/${MyAthenaWorkGroup}'
-      Roles:
-        - !Ref InitLambdaExecutionRole
 
   InitLambdaExecutionRoleBucketPolicy:
     Type: AWS::IAM::Policy
@@ -855,8 +823,6 @@ Resources:
           Value: !If [NeedAthenaWorkgroup, !Ref MyAthenaWorkGroup, '']
         - Key: IgnoreConditionalDependsOnDatabase
           Value: !If [NeedCURTable, !Ref MyGlueCURCrawler, '']
-        - Key: IgnoreConditionalDependsOnPolicy1
-          Value: !If [NeedAthenaWorkgroup, !Ref InitLambdaExecutionRoleWorkGroupPolicy, '']
         - Key: IgnoreConditionalDependsOnPolicy2
           Value: !If [NeedAthenaQueryResultsBucket, !Ref InitLambdaExecutionRoleBucketPolicy, '']
         - Key: IgnoreConditionalDependsOnPolicy3


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Enables deletion of Athena Workgroup via CFN natively, by setting `RecursiveDeleteOption` to true
2. Adds `ExpectedBucketOwner` for better security

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
