### PR TITLE
Update cid-cfn.yml

### DIFF
--- a/cfn-templates/cid-cfn.yml
+++ b/cfn-templates/cid-cfn.yml
@@ -1795,7 +1795,7 @@ Resources:
           quicksight_user: !Ref QuickSightUser
           account_map_source: 'dummy' #initial
           share_with_account: !Ref ShareDashboard
-          account-map-database-name: !If [NeedDatabase, !Ref CidDatabase, !Ref DatabaseName ]
+          account_map_database_name: !If [NeedDatabase, !Ref CidDatabase, !Ref DatabaseName ]
     Metadata:
       cfn_nag:
         rules_to_suppress:


### PR DESCRIPTION
Fix: Correct environment variable map key format for CidExec resource

In the CloudFormation deployment of the CidExec resource, an error was encountered due to an invalid map key format in the environment variables. CloudFormation returned an error indicating that environment variable names must adhere to the regular expression pattern `[a-zA-Z]([a-zA-Z0-9_])+`, meaning they must start with a letter and can only contain letters, numbers, and underscores.

The key `account-map-database-name` contained a hyphen, which caused the validation failure. Replaced the hyphen with an underscore to comply with the naming convention for Lambda environment variable keys.

Fixes the CloudFormation error in the CidExec resource.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
