### PR TITLE
Fix billing_period splitting in kpi_ebs_snap_view sql query

### DIFF
--- a/cid/builtin/core/data/queries/kpi/kpi_ebs_snap_view.sql
+++ b/cid/builtin/core/data/queries/kpi/kpi_ebs_snap_view.sql
@@ -8,8 +8,8 @@ CREATE OR REPLACE VIEW kpi_ebs_snap AS
 		-- Step 2: Filter CUR to return all ebs ec2 snapshot usage data
 		snapshot_usage_all_time AS (
 		   SELECT
-			 split_part(billing_period, '/', 1) year
-		   , split_part(billing_period, '/', 2) month
+			 split_part(billing_period, '-', 1) year
+		   , split_part(billing_period, '-', 2) month
 		   , bill_billing_period_start_date billing_period
 		   , line_item_usage_start_date usage_start_date
 		   , bill_payer_account_id payer_account_id


### PR DESCRIPTION
*Issue #, if available:*
Athena view kpi_ebs_snap doesn't give any output due to the bug we fixed here. 

*Description of changes:*
I replaced the splitting sign for billing_period in lines 11 and 12 of kpi_ebs_snap_view SQL query because the original code doesn't output any result from CUR 2.0 data export.
Originally the code tries to split the billing_period var using a forward slash (/) and we replaced it with a dash (-).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
