### PR TITLE
Add missing s3:PutBucketTagging permissions for SourceS3 in data-expo…

### DIFF
--- a/cfn-templates/cid-admin-policies.yaml
+++ b/cfn-templates/cid-admin-policies.yaml
@@ -696,6 +696,7 @@ Resources:
           - s3:PutBucketOwnershipControls
           - s3:PutBucketPolicy
           - s3:PutBucketPublicAccessBlock
+          - s3:PutBucketTagging
           - s3:PutBucketVersioning
           - s3:PutEncryptionConfiguration
           - s3:PutLifecycleConfiguration


### PR DESCRIPTION
…rts-aggregation

SourceS3 in data-exports-aggregation creates tags but s3:PutBucketTagging permission for those who use cid-admin-policies is missing. 

https://github.com/awslabs/cid-data-collection-framework/blob/1d6678ad14b396777349faa7c4bbd539735caf75/data-exports/deploy/data-exports-aggregation.yaml#L381

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
